### PR TITLE
Bundle gems in vendor directory

### DIFF
--- a/vnmgr/.bundle/config
+++ b/vnmgr/.bundle/config
@@ -1,0 +1,4 @@
+---
+BUNDLE_PATH: vendor/bundle
+BUNDLE_DISABLE_SHARED_GEMS: '1'
+BUNDLE_WITHOUT: test


### PR DESCRIPTION
I added the .bundle/config file so "bundle install" puts gems in the vendor directory and doesn't share them with other software.
