### PR TITLE
Remove backend_namespace from model wrappers

### DIFF
--- a/vnmgr/lib/vnmgr/model_wrappers/datapath_wrapper.rb
+++ b/vnmgr/lib/vnmgr/model_wrappers/datapath_wrapper.rb
@@ -2,7 +2,6 @@
 
 module Vnmgr::ModelWrappers
   class DatapathWrapper < Base
-    backend_namespace = "datapaths"
 
     def to_hash
       {

--- a/vnmgr/lib/vnmgr/model_wrappers/dc_network_wrapper.rb
+++ b/vnmgr/lib/vnmgr/model_wrappers/dc_network_wrapper.rb
@@ -2,7 +2,6 @@
 
 module Vnmgr::ModelWrappers
   class DcNetworkWrapper < Base
-    backend_namespace = "dc_networks"
 
     def to_hash
       {

--- a/vnmgr/lib/vnmgr/model_wrappers/dhcp_range_wrapper.rb
+++ b/vnmgr/lib/vnmgr/model_wrappers/dhcp_range_wrapper.rb
@@ -2,7 +2,6 @@
 
 module Vnmgr::ModelWrappers
   class DhcpRangeWrapper < Base
-    backend_namespace = "dhcp_ranges"
 
     def to_hash
       {

--- a/vnmgr/lib/vnmgr/model_wrappers/ip_address_wrapper.rb
+++ b/vnmgr/lib/vnmgr/model_wrappers/ip_address_wrapper.rb
@@ -2,7 +2,6 @@
 
 module Vnmgr::ModelWrappers
   class IpAddressWrapper < Base
-    backend_namespace = "ip_addresses"
 
     def to_hash
       {

--- a/vnmgr/lib/vnmgr/model_wrappers/ip_lease_wrapper.rb
+++ b/vnmgr/lib/vnmgr/model_wrappers/ip_lease_wrapper.rb
@@ -2,7 +2,6 @@
 
 module Vnmgr::ModelWrappers
   class IpLeaseWrapper < Base
-    backend_namespace = "ip_leases"
 
     def to_hash
       {

--- a/vnmgr/lib/vnmgr/model_wrappers/mac_lease_wrapper.rb
+++ b/vnmgr/lib/vnmgr/model_wrappers/mac_lease_wrapper.rb
@@ -2,7 +2,6 @@
 
 module Vnmgr::ModelWrappers
   class MacLeaseWrapper < Base
-    backend_namespace = "mac_leases"
 
     def to_hash
       {

--- a/vnmgr/lib/vnmgr/model_wrappers/mac_range_wrapper.rb
+++ b/vnmgr/lib/vnmgr/model_wrappers/mac_range_wrapper.rb
@@ -2,7 +2,6 @@
 
 module Vnmgr::ModelWrappers
   class MacRangeWrapper < Base
-    backend_namespace = "mac_ranges"
 
     def to_hash
       {

--- a/vnmgr/lib/vnmgr/model_wrappers/network_service_wrapper.rb
+++ b/vnmgr/lib/vnmgr/model_wrappers/network_service_wrapper.rb
@@ -2,7 +2,6 @@
 
 module Vnmgr::ModelWrappers
   class NetworkServiceWrapper < Base
-    backend_namespace = "network_services"
 
     def to_hash
       {

--- a/vnmgr/lib/vnmgr/model_wrappers/network_wrapper.rb
+++ b/vnmgr/lib/vnmgr/model_wrappers/network_wrapper.rb
@@ -2,7 +2,6 @@
 
 module Vnmgr::ModelWrappers
   class NetworkWrapper < Base
-    backend_namespace = "network"
 
     def to_hash
       {

--- a/vnmgr/lib/vnmgr/model_wrappers/open_flow_controller_wrapper.rb
+++ b/vnmgr/lib/vnmgr/model_wrappers/open_flow_controller_wrapper.rb
@@ -2,7 +2,6 @@
 
 module Vnmgr::ModelWrappers
   class OpenFlowControllerWrapper < Base
-    backend_namespace = "open_flow_controllers"
 
     def to_hash
       {

--- a/vnmgr/lib/vnmgr/model_wrappers/router_wrapper.rb
+++ b/vnmgr/lib/vnmgr/model_wrappers/router_wrapper.rb
@@ -2,7 +2,6 @@
 
 module Vnmgr::ModelWrappers
   class RouterWrapper < Base
-    backend_namespace = "routers"
 
     def to_hash
       {

--- a/vnmgr/lib/vnmgr/model_wrappers/tunnel_wrapper.rb
+++ b/vnmgr/lib/vnmgr/model_wrappers/tunnel_wrapper.rb
@@ -2,7 +2,6 @@
 
 module Vnmgr::ModelWrappers
   class TunnelWrapper < Base
-    backend_namespace = "tunnels"
 
     def to_hash
       {

--- a/vnmgr/lib/vnmgr/model_wrappers/vif_wrapper.rb
+++ b/vnmgr/lib/vnmgr/model_wrappers/vif_wrapper.rb
@@ -2,7 +2,6 @@
 
 module Vnmgr::ModelWrappers
   class VifWrapper < Base
-    backend_namespace = "vifs"
 
     def to_hash
       {


### PR DESCRIPTION
The backend_namespace in the model wrappers is a leftover from a design idea I had and threw away very early. It is not used anywhere so we should remove it.
