### PR TITLE
Quick fix for interfaces security groups api

### DIFF
--- a/vnctl/lib/vnctl/cli/interface.rb
+++ b/vnctl/lib/vnctl/cli/interface.rb
@@ -8,8 +8,7 @@ module Vnctl::Cli
     desc "add INTERFACE_UUID, SECURITY_GROUP_UUID(S)", "Adds one or more security groups to an interface."
     def add(interface_uuid, *secg_uuids)
       secg_uuids.each { |secg_uuid|
-        query = { :security_group_uuid => secg_uuid }
-        puts post("#{suffix}/#{interface_uuid}/security_groups", :query => query)
+        puts post("#{suffix}/#{interface_uuid}/security_groups/#{secg_uuid}")
       }
     end
 

--- a/vnet/lib/vnet/endpoints/1.0/interfaces.rb
+++ b/vnet/lib/vnet/endpoints/1.0/interfaces.rb
@@ -48,7 +48,7 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/interfaces' do
     }
   end
 
-  post '/:uuid/security_groups' do
+  post '/:uuid/security_groups/:security_group_uuid' do
     params = parse_params(@params, ['uuid', 'security_group_uuid'])
     check_required_params(params, ['uuid', 'security_group_uuid'])
 


### PR DESCRIPTION
While working on the integration test, I noticed that the interface_security_groups endpoint behaves differently from datapath_networks and datapath_route_links. This is a quick fix to make it behave exactly like the others.
