### PR TITLE
The webapi needs to require yaml so it can encode its responses in it

### DIFF
--- a/vnet/lib/sinatra/vnet_api_setup.rb
+++ b/vnet/lib/sinatra/vnet_api_setup.rb
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 require 'json'
+require 'yaml'
 
 require 'sinatra/respond_with'
 require 'sinatra/namespace'


### PR DESCRIPTION
Before this change the webapi wouldn't return yml unless json had been used once before.
