### PR TITLE
Quick fix for a crash in Services::Base

### DIFF
--- a/vnet/lib/vnet/openflow/services/base.rb
+++ b/vnet/lib/vnet/openflow/services/base.rb
@@ -61,8 +61,8 @@ module Vnet::Openflow::Services
       cookie(OPTIONAL_TYPE_NETWORK, value)
     end
 
-    def del_cookie_for_network(value, options = {})
-      del_cookie(OPTIONAL_TYPE_NETWORK, value, options)
+    def del_cookie_for_network(value)
+      del_cookie(OPTIONAL_TYPE_NETWORK, value)
     end
 
     def log_format(message, values = nil)


### PR DESCRIPTION
del_cookie which takes 2 parameters was called with 3 parameters. That didn't really work.
