### PR TITLE
vnctl interface uuid bugfix

### DIFF
--- a/vnctl/lib/vnctl/cli/interface.rb
+++ b/vnctl/lib/vnctl/cli/interface.rb
@@ -16,6 +16,7 @@ module Vnctl::Cli
         :desc => "The uuid of the datapath that owns this interface."
     }
 
+    option_uuid
     add_modify_shared_options
     option :network_uuid, :type => :string, :desc => "The uuid of the network this interface is in."
     option :mac_address, :type => :string, :desc => "The mac address for this interface."


### PR DESCRIPTION
When I refactored the interfaces cli, I forgot to allow users to set a uuid when adding a new interface. :( Fixed.
