### PR TITLE
update hostname. [ci skip]

### DIFF
--- a/docs/InstallGuide.md
+++ b/docs/InstallGuide.md
@@ -21,11 +21,11 @@ Pre-setup
 
 Download the openvnet.repo file and put it to your /etc/yum.repos.d/ directory.
 
-    # curl -o /etc/yum.repos.d/openvnet.repo -R https://raw.github.com/axsh/openvnet/master/openvnet.repo
+    # curl -o /etc/yum.repos.d/openvnet.repo -R https://raw.githubusercontent.com/axsh/openvnet/master/openvnet.repo
 
 Download the openvnet-third-party.repo file and put it in your /etc/yum.repos.d/ directory.
 
-    # curl -o /etc/yum.repos.d/openvnet-third-party.repo -R https://raw.github.com/axsh/openvnet/master/openvnet-third-party.repo
+    # curl -o /etc/yum.repos.d/openvnet-third-party.repo -R https://raw.githubusercontent.com/axsh/openvnet/master/openvnet-third-party.repo
 
 Install epel-release.
 


### PR DESCRIPTION
via https://developer.github.com/changes/2014-04-25-user-content-security/

> In order to better isolate your content from potentially malicious content uploaded by other users (e.g., content that might contain Cross-Site Scripting or other embedded attacks), we now serve user-generated content from subdomains of githubusercontent.com. This content is no longer served from subdomains of github.com.

`raw.github.com` -> `raw.githubusercontent.com`
