### PR TITLE
update openvswitch version. 1.10.0 -> 2.3.0

### DIFF
--- a/deployment/packagebuild/packages.d/third_party/openvnet-openvswitch/rpmbuild.sh
+++ b/deployment/packagebuild/packages.d/third_party/openvnet-openvswitch/rpmbuild.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-ovs_version="1.10.0"
+ovs_version="2.3.0"
 
 work_dir=${WORK_DIR:-/tmp/vnet-rpmbuild}
 package_work_dir=${work_dir}/packages.d/third_party/openvnet-openvswitch


### PR DESCRIPTION
This change is In order to support CentOS-6.5.
If CI uses openvswitch-2.3.0 on CentOS-6.5, the build gets a success.
