### PR TITLE
fix rpm arch type.

### DIFF
--- a/deployment/packagebuild/packages.d/vnet/openvnet-common/recipe.rb
+++ b/deployment/packagebuild/packages.d/vnet/openvnet-common/recipe.rb
@@ -5,7 +5,7 @@ class OpenvnetCommon < FPM::Cookery::Recipe
   version (ENV['BUILD_TIME'] || Time.now.strftime('%Y%m%d%H%M%S')) + (ENV['GIT_COMMIT'] ? "git#{ENV['GIT_COMMIT'].slice(0, 7)}" : "spot")
   #source   'https://github.com/axsh/openvnet/', :with => :git
   source   File.expand_path("../../../../../", File.dirname(__FILE__)), :with => :local_path
-  arch 'all'
+  #arch 'all' # should be x86_64
   depends *%w(
     zeromq3-devel
     openvnet-ruby


### PR DESCRIPTION
The current issue is that the rpm type is noarch even it it include binari files.
This change will fix to specify arch type to x86_64 from noarch.

The failed build was not rpmbuild but integration test.

```
12:40:57 ++ basename /var/lib/jenkins/workspace/openvnet.rpmbuild-vnet/deployment/packagebuild/packages.d/vnet/openvnet-common
12:40:57 + build_package openvnet-common
12:40:57 + local name=openvnet-common
12:40:57 + local recipe_dir=/var/lib/jenkins/workspace/openvnet.rpmbuild-vnet/deployment/packagebuild/packages.d/vnet/openvnet-common
12:40:57 + local package_work_dir=/tmp/vnet-rpmbuild/packages.d/vnet/openvnet-common
12:40:57 + [[ -f /var/lib/jenkins/workspace/openvnet.rpmbuild-vnet/deployment/packagebuild/packages.d/vnet/openvnet-common/recipe.rb ]]
12:40:57 + mkdir /tmp/vnet-rpmbuild/packages.d/vnet/openvnet-common
12:40:57 + cd /var/lib/jenkins/workspace/openvnet.rpmbuild-vnet/deployment/packagebuild/packages.d/vnet/openvnet-common
12:40:57 + BUILD_TIME=20141016123128
12:40:57 + /var/lib/jenkins/workspace/openvnet.rpmbuild-vnet/deployment/packagebuild/bin/fpm-cook --workdir /tmp/vnet-rpmbuild/packages.d/vnet/openvnet-common --no-deps
12:41:09 ===> Starting package creation for openvnet-common-20141016123128gitde0d3c3 (centos, rpm)
12:41:09 ===> 
12:41:09 ===> Fetching source: 
12:41:09 ===> Copying /var/lib/jenkins/workspace/openvnet.rpmbuild-vnet to cache
12:41:09 ===> Building in /tmp/vnet-rpmbuild/packages.d/vnet/openvnet-common/tmp-build/openvnet.rpmbuild-vnet
12:41:09 ===> Installing into /tmp/vnet-rpmbuild/packages.d/vnet/openvnet-common/tmp-dest
12:41:13 ===> [FPM] Converting dir to rpm {"file":"fpm/package.rb","line":"189"}
12:41:13 WARNING: [FPM] no value for epoch is set, defaulting to nil {"file":"fpm/package/rpm.rb","line":"386"}
12:41:13 WARNING: [FPM] no value for epoch is set, defaulting to nil {"file":"fpm/package/rpm.rb","line":"386"}
12:41:13 ===> [FPM] Reading template {"path":"/var/lib/jenkins/workspace/openvnet.rpmbuild-vnet/deployment/packagebuild/vendor/bundle/ruby/2.1.0/gems/fpm-0.4.42/templates/rpm.erb","file":"fpm/package.rb","line":"322"}
12:41:14 ===> [FPM] Running rpmbuild {"args":["rpmbuild","-bb","--define","buildroot /tmp/package-rpm-build20141016-1675-6pepf9/BUILD","--define","_topdir /tmp/package-rpm-build20141016-1675-6pepf9","--define","_sourcedir /tmp/package-rpm-build20141016-1675-6pepf9","--define","_rpmdir /tmp/package-rpm-build20141016-1675-6pepf9/RPMS","/tmp/package-rpm-build20141016-1675-6pepf9/SPECS/openvnet-common.spec"],"file":"fpm/package/rpm.rb","line":"351"}
12:41:59 ===> [FPM] Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.RayxDl {"file":"cabin/mixins/pipe.rb","line":"46"}
12:41:59 ===> [FPM] Executing(%build): /bin/sh -e /var/tmp/rpm-tmp.EObaia {"file":"cabin/mixins/pipe.rb","line":"46"}
12:41:59 ===> [FPM] Executing(%install): /bin/sh -e /var/tmp/rpm-tmp.OVueXY {"file":"cabin/mixins/pipe.rb","line":"46"}
12:41:59 ===> [FPM] Processing files: openvnet-common-20141016123128gitde0d3c3.fpm0-1.x86_64 {"file":"cabin/mixins/pipe.rb","line":"46"}
12:41:59 ===> [FPM] Wrote: /tmp/package-rpm-build20141016-1675-6pepf9/RPMS/x86_64/openvnet-common-20141016123128gitde0d3c3.fpm0-1.x86_64.rpm {"file":"cabin/mixins/pipe.rb","line":"46"}
12:41:59 ===> [FPM] Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.QfKStP {"file":"cabin/mixins/pipe.rb","line":"46"}
12:41:59 ===> [FPM] Created rpm {"path":"openvnet-common-20141016123128gitde0d3c3.fpm0-1.x86_64.rpm","file":"fpm/cookery/packager.rb","line":"185"}
12:41:59 WARNING: [FPM] no value for epoch is set, defaulting to nil {"file":"fpm/package/rpm.rb","line":"386"}
12:41:59 ===> Created package: /tmp/vnet-rpmbuild/packages.d/vnet/openvnet-common/pkg/openvnet-common-20141016123128gitde0d3c3.fpm0-1.x86_64.rpm
12:41:59 + for arch in '${possible_archs}'
12:41:59 + :
12:41:59 + cp '/tmp/vnet-rpmbuild/packages.d/vnet/openvnet-common/pkg/*i386.rpm' /var/www/html/repos/packages/rhel/6/vnet/20141016123128gitde0d3c3/i386
12:41:59 cp: cannot stat `/tmp/vnet-rpmbuild/packages.d/vnet/openvnet-common/pkg/*i386.rpm': No such file or directory
12:41:59 + for arch in '${possible_archs}'
12:41:59 + :
12:41:59 + cp '/tmp/vnet-rpmbuild/packages.d/vnet/openvnet-common/pkg/*noarch.rpm' /var/www/html/repos/packages/rhel/6/vnet/20141016123128gitde0d3c3/noarch
12:41:59 cp: cannot stat `/tmp/vnet-rpmbuild/packages.d/vnet/openvnet-common/pkg/*noarch.rpm': No such file or directory
12:41:59 + for arch in '${possible_archs}'
12:41:59 + :
12:41:59 + cp /tmp/vnet-rpmbuild/packages.d/vnet/openvnet-common/pkg/openvnet-common-20141016123128gitde0d3c3.fpm0-1.x86_64.rpm /var/www/html/repos/packages/rhel/6/vnet/20141016123128gitde0d3c3/x86_64
```
