### PR TITLE
Fix dcell start

### DIFF
--- a/deployment/conf_files/etc/openvnet/common.conf
+++ b/deployment/conf_files/etc/openvnet/common.conf
@@ -1,8 +1,30 @@
+#
+# adapter : The name of key-value store. Defalut value is 'redis'.
+#
+#    host : IP address of the key-value store.
+#
+#    port : Listen port of the process.
+#
+
 registry {
   adapter "redis"
   host "127.0.0.1"
   port 6379
 }
+
+#
+#  adapter : The adapter name for the database.
+#
+#     host : IP address of the db server.
+#
+# database : The name of the database.
+#
+#     port : Listen port of the db server.
+#
+#     user : User name of the db server.
+#
+# password : Password of the db server.
+#
 
 db {
   adapter "mysql2"

--- a/deployment/conf_files/etc/openvnet/vna.conf
+++ b/deployment/conf_files/etc/openvnet/vna.conf
@@ -3,6 +3,7 @@ node {
   addr {
     protocol "tcp"
     host "127.0.0.1"
+    # specify public/global IP address if it runs in a NAT environment.
     public ""
     port 9103
   }

--- a/deployment/conf_files/etc/openvnet/vna.conf
+++ b/deployment/conf_files/etc/openvnet/vna.conf
@@ -1,13 +1,33 @@
+#
+#       id : The ID of the OpenVNet's process. It should be unique among the entire world of the OpenVNet.
+#
+# protocol : This parameter can be used to specify the 0MQ address. Default value is 'tcp'.
+#
+#     host : Private IP address that can be used to specify the 0MQ address. 
+#
+#   public : Public/Global IP address that is linked to the private IP address specified by the 'host' parameter.
+#            A 0MQ socket will be created with the public/global IP address if this paramter is specified.
+#            Otherwise 'host' parameter will be used to create a 0MQ socket.
+#
+#     port : Listen port of the process.
+#
+#
+
 node {
   id "vna"
   addr {
     protocol "tcp"
     host "127.0.0.1"
-    # specify public/global IP address if it runs in a NAT environment.
     public ""
     port 9103
   }
 }
+
+#
+#    uuid : The uuid of the public/physical network in which the vna participates.
+#
+# address : The gateway address of the network specified by the 'uuid'.
+#
 
 network {
   uuid ""

--- a/deployment/conf_files/etc/openvnet/vna.conf
+++ b/deployment/conf_files/etc/openvnet/vna.conf
@@ -3,6 +3,7 @@ node {
   addr {
     protocol "tcp"
     host "127.0.0.1"
+    public ""
     port 9103
   }
 }

--- a/deployment/conf_files/etc/openvnet/vnmgr.conf
+++ b/deployment/conf_files/etc/openvnet/vnmgr.conf
@@ -3,6 +3,7 @@ node {
   addr {
     protocol "tcp"
     host "127.0.0.1"
+    # specify public/global IP address if it runs in a NAT environment.
     public ""
     port 9102
   }

--- a/deployment/conf_files/etc/openvnet/vnmgr.conf
+++ b/deployment/conf_files/etc/openvnet/vnmgr.conf
@@ -1,9 +1,25 @@
+#
+#       id : The ID of the OpenVNet's process. It should be unique among the entire world of the OpenVNet.
+#
+# protocol : This parameter can be used to specify the 0MQ address. Default value is 'tcp'.
+#
+#     host : Private IP address that can be used to specify the 0MQ address. 
+#
+#   public : Public/Global IP address that is linked to the private IP address specified by the 'host' parameter.
+#            A 0MQ socket will be created with the public/global IP address if this paramter is specified.
+#            Otherwise 'host' parameter will be used to create a 0MQ socket.
+#
+#     port : Listen port of the process.
+#
+#  plugins : A list of plugins for vnmgr process. vdc_vnet_plugin is used as default value but it can be blank
+#            if it does not run with Wakame-vdc.
+#
+
 node {
   id "vnmgr"
   addr {
     protocol "tcp"
     host "127.0.0.1"
-    # specify public/global IP address if it runs in a NAT environment.
     public ""
     port 9102
   }

--- a/deployment/conf_files/etc/openvnet/vnmgr.conf
+++ b/deployment/conf_files/etc/openvnet/vnmgr.conf
@@ -3,6 +3,7 @@ node {
   addr {
     protocol "tcp"
     host "127.0.0.1"
+    public ""
     port 9102
   }
   plugins [:vdc_vnet_plugin]

--- a/deployment/conf_files/etc/openvnet/webapi.conf
+++ b/deployment/conf_files/etc/openvnet/webapi.conf
@@ -1,9 +1,25 @@
+#
+#       id : The ID of the OpenVNet's process. It should be unique among the entire world of the OpenVNet.
+#
+# protocol : This parameter can be used to specify the 0MQ address. Default value is 'tcp'.
+#
+#     host : Private IP address that can be used to specify the 0MQ address. 
+#
+#   public : Public/Global IP address that is linked to the private IP address specified by the 'host' parameter.
+#            A 0MQ socket will be created with the public/global IP address if this paramter is specified.
+#            Otherwise 'host' parameter will be used to create a 0MQ socket.
+#
+#     port : Listen port of the process.
+#
+#  plugins : A list of plugins for vnmgr process. vdc_vnet_plugin is used as default value but it can be blank
+#            if it does not run with Wakame-vdc.
+#
+
 node {
   id "webapi"
   addr {
     protocol "tcp"
     host "127.0.0.1"
-    # specify public/global IP address if it runs in a NAT environment.
     public ""
     port 9101
   }

--- a/deployment/conf_files/etc/openvnet/webapi.conf
+++ b/deployment/conf_files/etc/openvnet/webapi.conf
@@ -3,6 +3,7 @@ node {
   addr {
     protocol "tcp"
     host "127.0.0.1"
+    public ""
     port 9101
   }
 }

--- a/deployment/conf_files/etc/openvnet/webapi.conf
+++ b/deployment/conf_files/etc/openvnet/webapi.conf
@@ -3,6 +3,7 @@ node {
   addr {
     protocol "tcp"
     host "127.0.0.1"
+    # specify public/global IP address if it runs in a NAT environment.
     public ""
     port 9101
   }

--- a/vnet/bin/vna
+++ b/vnet/bin/vna
@@ -32,12 +32,19 @@ when :direct
   Vnet::Initializers::DB.run(conf.db_uri)
 end
 
-DCell.start(:id => conf.node.id, :addr => conf.node.addr_string,
+params = {
+  :id => conf.node.id,
+  :addr => conf.node.addr_string,
   :registry => {
     :adapter => conf.registry.adapter,
     :host => conf.registry.host,
     :port => conf.registry.port
-})
+  }
+}
+
+params.merge!(:public => conf.node.pub_addr_string) if conf.node.addr.public != ""
+
+DCell.start(params)
 
 
 trap 'TTIN' do

--- a/vnet/bin/vnmgr
+++ b/vnet/bin/vnmgr
@@ -14,12 +14,19 @@ conf = Vnet::Configurations::Vnmgr.conf
 
 Vnet::Initializers::DB.run(conf.db_uri)
 
-DCell.start :id => conf.node.id, :addr => conf.node.addr_string,
+params = {
+  :id => conf.node.id,
+  :addr => conf.node.addr_string,
   :registry => {
     :adapter => conf.registry.adapter,
     :host => conf.registry.host,
     :port => conf.registry.port
   }
+}
+
+params.merge!(:public => conf.node.pub_addr_string) if conf.node.addr.public != ""
+
+DCell.start(params)
 
 Vnet::NodeModules::Rpc.supervise_as :rpc
 Vnet::NodeModules::EventHandler.supervise_as :event_handler

--- a/vnet/lib/vnet/configurations/vna.rb
+++ b/vnet/lib/vnet/configurations/vna.rb
@@ -8,6 +8,7 @@ module Vnet::Configurations
       class Addr < Fuguta::Configuration
         param :protocol, :default => "tcp"
         param :host, :default => "127.0.0.1"
+        param :public, :default => ""
         param :port, :default => 9103
       end
 
@@ -15,6 +16,7 @@ module Vnet::Configurations
         def addr(&block)
           @config[:addr] = Addr.new.tap {|c| c.parse_dsl(&block) if block }
           @config[:addr_string] = "#{@config[:addr].protocol}://#{@config[:addr].host}:#{@config[:addr].port}"
+          @config[:pub_addr_string] = "#{@config[:addr].protocol}://#{@config[:addr].public}:#{@config[:addr].port}"
         end
       end
     end

--- a/vnet/lib/vnet/configurations/vnmgr.rb
+++ b/vnet/lib/vnet/configurations/vnmgr.rb
@@ -9,6 +9,7 @@ module Vnet::Configurations
       class Addr < Fuguta::Configuration
         param :protocol, :default => "tcp"
         param :host, :default => "127.0.0.1"
+        param :public, :default => ""
         param :port, :default => 9102
       end
 
@@ -16,6 +17,7 @@ module Vnet::Configurations
         def addr(&block)
           @config[:addr] = Addr.new.tap {|c| c.parse_dsl(&block) if block }
           @config[:addr_string] = "#{@config[:addr].protocol}://#{@config[:addr].host}:#{@config[:addr].port}"
+          @config[:pub_addr_string] = "#{@config[:addr].protocol}://#{@config[:addr].public}:#{@config[:addr].port}"
         end
       end
     end

--- a/vnet/lib/vnet/configurations/webapi.rb
+++ b/vnet/lib/vnet/configurations/webapi.rb
@@ -9,6 +9,7 @@ module Vnet::Configurations
       class Addr < Fuguta::Configuration
         param :protocol, :default => "tcp"
         param :host, :default => "127.0.0.1"
+        param :public, :default => ""
         param :port, :default => 9101
       end
 
@@ -16,6 +17,7 @@ module Vnet::Configurations
         def addr(&block)
           @config[:addr] = Addr.new.tap {|c| c.parse_dsl(&block) if block }
           @config[:addr_string] = "#{@config[:addr].protocol}://#{@config[:addr].host}:#{@config[:addr].port}"
+          @config[:pub_addr_string] = "#{@config[:addr].protocol}://#{@config[:addr].public}:#{@config[:addr].port}"
         end
       end
     end

--- a/vnet/rack/config-webapi.ru
+++ b/vnet/rack/config-webapi.ru
@@ -24,11 +24,19 @@ when :direct
   Vnet::Initializers::DB.run(conf.db_uri)
 end
 
-DCell.start(:id => conf.node.id, :addr => conf.node.addr_string,
+params = {
+  :id => conf.node.id,
+  :addr => conf.node.addr_string,
   :registry => {
     :adapter => conf.registry.adapter,
     :host => conf.registry.host,
-    :port => conf.registry.port })
+    :port => conf.registry.port
+  }
+}
+
+params.merge!(:public => conf.node.pub_addr_string) if conf.node.addr.public != ""
+
+DCell.start(params)
 
 map '/api' do
   use Rack::Cors do


### PR DESCRIPTION
There is a need to specify global IP address for the agents in its configuration file and DCell.start.