### PR TITLE
Bugfix run vnctl without ruby in PATH

### DIFF
--- a/deployment/conf_files/usr/bin/vnctl
+++ b/deployment/conf_files/usr/bin/vnctl
@@ -4,7 +4,7 @@ set -e
 static_ruby_path="/opt/axsh/openvnet/ruby/bin/ruby"
 vnctl_path="/opt/axsh/openvnet/vnctl/bin/vnctl"
 
-if [ -x $static_ruby_path  ]; then
+if [ -x $static_ruby_path ]; then
   $static_ruby_path $vnctl_path $@
 else
   $vnctl_path $@

--- a/deployment/conf_files/usr/bin/vnctl
+++ b/deployment/conf_files/usr/bin/vnctl
@@ -4,7 +4,7 @@ set -e
 static_ruby_path="/opt/axsh/openvnet/ruby/bin/ruby"
 vnctl_path="/opt/axsh/openvnet/vnctl/bin/vnctl"
 
-if [ -f $static_ruby_path  ]; then
+if [ -x $static_ruby_path  ]; then
   $static_ruby_path $vnctl_path $@
 else
   $vnctl_path $@

--- a/deployment/conf_files/usr/bin/vnctl
+++ b/deployment/conf_files/usr/bin/vnctl
@@ -1,4 +1,11 @@
 #!/bin/sh
 set -e
 
-/opt/axsh/openvnet/vnctl/bin/vnctl $@
+static_ruby_path="/opt/axsh/openvnet/ruby/bin/ruby"
+vnctl_path="/opt/axsh/openvnet/vnctl/bin/vnctl"
+
+if [ -f $static_ruby_path  ]; then
+  $static_ruby_path $vnctl_path $@
+else
+  $vnctl_path $@
+fi


### PR DESCRIPTION
### Problem

When installing the `openvnet-vnctl`RPM, vnctl wouldn't start unless ruby was in the `PATH` variable.

Since vnctl depends on `openvnet-ruby`, it should use that one but we can't put it in the user's `PATH`. they might have another ruby in there. Also, I don't want to have a shebang that hard codes vnctl to use the binary that `openvnet-ruby` provides.

### Solution

Have the shell script `/usr/bin/vnctl` (which is installed with the `openvnet-vnctl` RPM) check if the `openvnet-ruby` binary exists. Use it if it exists, otherwise run vnctl directly which will make it use whatever ruby is in `PATH`