### PR TITLE
Fix UniqueContraintViolation and symbol (:gre, :mac2mac) mysql errors

### DIFF
--- a/vnet/lib/vnet/core/tunnel_manager.rb
+++ b/vnet/lib/vnet/core/tunnel_manager.rb
@@ -297,10 +297,8 @@ module Vnet::Core
       info log_format("creating tunnel entry mode '#{tunnel_mode}'",
                       options.map { |k, v| "#{k}:#{v}" }.join(" "))
 
-      if @mutex_create_tunnel.locked?
-        while @mutex_create_tunnel.locked? | @mutex_create_tunnel.owned? do
-          sleep(1)
-        end
+      while @mutex_create_tunnel.locked? | @mutex_create_tunnel.owned? do
+        sleep(1)
       end
       @mutex_create_tunnel.synchronize {
         tunnel = MW::Tunnel.find(options)

--- a/vnet/lib/vnet/core/tunnel_manager.rb
+++ b/vnet/lib/vnet/core/tunnel_manager.rb
@@ -297,15 +297,7 @@ module Vnet::Core
       info log_format("creating tunnel entry mode '#{tunnel_mode}'",
                       options.map { |k, v| "#{k}:#{v}" }.join(" "))
 
-      while @mutex_create_tunnel.locked? | @mutex_create_tunnel.owned? do
-        sleep(1)
-      end
-      @mutex_create_tunnel.synchronize {
-        tunnel = MW::Tunnel.find(options)
-        if !tunnel
-          tunnel = MW::Tunnel.create(options.merge(mode: tunnel_mode))
-        end
-      }
+      tunnel = MW::Tunnel.create_or_find(options.merge(mode: tunnel_mode))
 
       internal_retrieve(options)
     end

--- a/vnet/lib/vnet/core/tunnel_manager.rb
+++ b/vnet/lib/vnet/core/tunnel_manager.rb
@@ -33,8 +33,6 @@ module Vnet::Core
       @host_route_links = {}
       @remote_datapath_networks = {}
       @remote_datapath_route_links = {}
-
-      @mutex_create_tunnel = Mutex.new
     end
 
     def update(params)

--- a/vnet/lib/vnet/core/tunnel_manager.rb
+++ b/vnet/lib/vnet/core/tunnel_manager.rb
@@ -112,9 +112,9 @@ module Vnet::Core
 
       case
       when src_interface[:network_id] != dst_interface[:network_id]
-        :gre
+        "gre"
       when src_interface[:network_id] == dst_interface[:network_id]
-        :mac2mac
+        "mac2mac"
       else
         nil
       end
@@ -148,9 +148,9 @@ module Vnet::Core
 
       item_class =
         case tunnel_mode
-        when :gre     then Tunnels::Gre
-        when :mac2mac then Tunnels::Mac2Mac
-        when :unknown then Tunnels::Unknown
+        when "gre"     then Tunnels::Gre
+        when "mac2mac" then Tunnels::Mac2Mac
+        when "unknown" then Tunnels::Unknown
         else
           return
         end

--- a/vnet/lib/vnet/core/tunnel_manager.rb
+++ b/vnet/lib/vnet/core/tunnel_manager.rb
@@ -107,8 +107,8 @@ module Vnet::Core
     def select_tunnel_mode(src_interface_id, dst_interface_id)
       src_interface = @interfaces[src_interface_id]
       dst_interface = @interfaces[dst_interface_id]
-      return :unknown unless src_interface && src_interface[:network_id]
-      return :unknown unless dst_interface && dst_interface[:network_id]
+      return "unknown" unless src_interface && src_interface[:network_id]
+      return "unknown" unless dst_interface && dst_interface[:network_id]
 
       case
       when src_interface[:network_id] != dst_interface[:network_id]

--- a/vnet/lib/vnet/core/tunnel_manager.rb
+++ b/vnet/lib/vnet/core/tunnel_manager.rb
@@ -105,13 +105,15 @@ module Vnet::Core
     def select_tunnel_mode(src_interface_id, dst_interface_id)
       src_interface = @interfaces[src_interface_id]
       dst_interface = @interfaces[dst_interface_id]
-      return "unknown" unless src_interface && src_interface[:network_id]
-      return "unknown" unless dst_interface && dst_interface[:network_id]
+      src_interface_network = src_interface[:network_id]
+      dst_interface_network = dst_interface[:network_id]
+      return "unknown" unless src_interface && src_interface_network
+      return "unknown" unless dst_interface && dst_interface_network
 
       case
-      when src_interface[:network_id] != dst_interface[:network_id]
+      when src_interface_network != dst_interface_network
         "gre"
-      when src_interface[:network_id] == dst_interface[:network_id]
+      when src_interface_network == dst_interface_network
         "mac2mac"
       else
         nil

--- a/vnet/lib/vnet/core/tunnels/base.rb
+++ b/vnet/lib/vnet/core/tunnels/base.rb
@@ -33,7 +33,7 @@ module Vnet::Core::Tunnels
     end
     
     def mode
-      :base
+      "base"
     end
 
     def log_type
@@ -159,7 +159,7 @@ module Vnet::Core::Tunnels
 
       @tunnel_port_number = new_port_number
 
-      return if self.mode != :gre
+      return if self.mode != "gre"
 
       @datapath_networks.each { |dpn|
         updated_networks[dpn[:network_id]] = true
@@ -170,7 +170,7 @@ module Vnet::Core::Tunnels
       return if @tunnel_port_number.nil?
       @tunnel_port_number = nil
 
-      return if self.mode != :gre
+      return if self.mode != "gre"
 
       @datapath_networks.each { |dpn|
         updated_networks[dpn[:network_id]] = true
@@ -183,7 +183,7 @@ module Vnet::Core::Tunnels
 
       @host_port_number = new_port_number
 
-      return if self.mode != :mac2mac
+      return if self.mode != "mac2mac"
 
       @datapath_networks.each { |dpn|
         updated_networks[dpn[:network_id]] = true

--- a/vnet/lib/vnet/core/tunnels/gre.rb
+++ b/vnet/lib/vnet/core/tunnels/gre.rb
@@ -5,7 +5,7 @@ module Vnet::Core::Tunnels
   class Gre < Base
 
     def mode
-      :gre
+      "gre"
     end
 
     def log_type

--- a/vnet/lib/vnet/core/tunnels/mac2mac.rb
+++ b/vnet/lib/vnet/core/tunnels/mac2mac.rb
@@ -5,7 +5,7 @@ module Vnet::Core::Tunnels
   class Mac2Mac < Base
 
     def mode
-      :mac2mac
+      "mac2mac"
     end
 
     def log_type

--- a/vnet/lib/vnet/core/tunnels/unknown.rb
+++ b/vnet/lib/vnet/core/tunnels/unknown.rb
@@ -5,7 +5,7 @@ module Vnet::Core::Tunnels
   class Unknown < Base
 
     def mode
-      :unknown
+      "unknown"
     end
 
     def log_type

--- a/vnet/lib/vnet/node_api/tunnel.rb
+++ b/vnet/lib/vnet/node_api/tunnel.rb
@@ -28,7 +28,7 @@ module Vnet::NodeApi
       end
 
       def create_or_find(options)
-        # Only create a tunnel if it doesn't exist yet       
+        # Only create a tunnel if it doesn't exist yet
         tunnel = find(options)
         if !tunnel
           tunnel = create(options)

--- a/vnet/lib/vnet/node_api/tunnel.rb
+++ b/vnet/lib/vnet/node_api/tunnel.rb
@@ -4,6 +4,7 @@ module Vnet::NodeApi
   class Tunnel < EventBase
     class << self
 
+
       def update_mode(id, mode)
         transaction do
           model_class[id].tap do |obj|
@@ -15,21 +16,51 @@ module Vnet::NodeApi
       end
 
       #
+      # Override find method to only use the unique identifiers to find an existing tunnel
+      #
+      def find(options)
+        tunnel = super({
+          :src_datapath_id => options[:src_datapath_id],
+          :dst_datapath_id => options[:dst_datapath_id],
+          :src_interface_id => options[:src_interface_id],
+          :dst_interface_id => options[:dst_interface_id]
+        })
+      end
+
+      def create_or_find(options)
+        # Only create a tunnel if it doesn't exist yet       
+        tunnel = find(options)
+        if !tunnel
+          tunnel = create(sanitize_options(options))
+        end
+        tunnel
+      end
+
+      #
       # Internal methods:
       #
 
       private
 
       def dispatch_created_item_events(model)
-        # dispatch_event(ADDED_TUNNEL, model.to_hash)
+         dispatch_event(ADDED_TUNNEL, model.to_hash)
       end
 
       def dispatch_deleted_item_events(model)
-        # dispatch_event(REMOVED_TUNNEL, id: model.id)
+         dispatch_event(REMOVED_TUNNEL, id: model.id)
 
         # no dependencies
+      end
+
+      def sanitize_options(options)
+         sanitized = options.clone
+         sanitized[:mode] = "#{options[:mode]}"
+         logger.debug(" %%%%%% OPTIONS SANITIZED #{sanitized} %%%%%%")
+
+         sanitized
       end
 
     end
   end
 end
+

--- a/vnet/lib/vnet/node_api/tunnel.rb
+++ b/vnet/lib/vnet/node_api/tunnel.rb
@@ -31,7 +31,7 @@ module Vnet::NodeApi
         # Only create a tunnel if it doesn't exist yet       
         tunnel = find(options)
         if !tunnel
-          tunnel = create(sanitize_options(options))
+          tunnel = create(options)
         end
         tunnel
       end
@@ -50,14 +50,6 @@ module Vnet::NodeApi
          dispatch_event(REMOVED_TUNNEL, id: model.id)
 
         # no dependencies
-      end
-
-      def sanitize_options(options)
-         sanitized = options.clone
-         sanitized[:mode] = "#{options[:mode]}"
-         logger.debug(" %%%%%% OPTIONS SANITIZED #{sanitized} %%%%%%")
-
-         sanitized
       end
 
     end

--- a/vnet/lib/vnet/openflow/metadata_helpers.rb
+++ b/vnet/lib/vnet/openflow/metadata_helpers.rb
@@ -23,7 +23,7 @@ module Vnet::Openflow
         when :local, :match_local, :write_local
           metadata = metadata | METADATA_FLAG_LOCAL
           metadata_mask = metadata_mask | METADATA_FLAG_LOCAL | METADATA_FLAG_REMOTE
-        when :mac2mac, :match_mac2mac, :write_mac2mac
+        when "mac2mac", :match_mac2mac, :write_mac2mac
           metadata = metadata | METADATA_FLAG_MAC2MAC
           metadata_mask = metadata_mask | METADATA_FLAG_MAC2MAC
         when :network, :match_network, :write_network


### PR DESCRIPTION
Prevents the following error in the vnmgr,log

```
I, [2015-04-23T06:03:30.392090 #10642]  INFO -- : failed to execute: class_name: tunnel method_name: execute args: [:create, {:src_datapath_id=>1, :dst_datapath_id=>2, :src_interface_id=>1, :dst_interface_id=>2, :mode=>:mac2mac}]
I, [2015-04-23T06:03:30.392181 #10642]  INFO -- : Mysql2::Error: Duplicate entry '1-2-1-2-0' for key 'tunnels_datapath_id_interface_id_index' (Sequel::UniqueConstraintViolation)
```
which resulted in the following error in the vna.log 

```
E, [2015-04-23T06:03:30.758691 #4820] ERROR -- : couldn't decode message
DCell::Server::InvalidMessageError: invalid message: undefined class/module Mysql2::
	/opt/axsh/openvnet/vnet/vendor/bundle/ruby/2.1.0/gems/dcell-0.15.0/lib/dcell/server.rb:59:in `rescue in decode_message'
	/opt/axsh/openvnet/vnet/vendor/bundle/ruby/2.1.0/gems/dcell-0.15.0/lib/dcell/server.rb:56:in `decode_message'
	/opt/axsh/openvnet/vnet/vendor/bundle/ruby/2.1.0/gems/dcell-0.15.0/lib/dcell/server.rb:38:in `handle_message'
	/opt/axsh/openvnet/vnet/vendor/bundle/ruby/2.1.0/gems/celluloid-0.15.2/lib/celluloid/calls.rb:25:in `public_send'
	/opt/axsh/openvnet/vnet/vendor/bundle/ruby/2.1.0/gems/celluloid-0.15.2/lib/celluloid/calls.rb:25:in `dispatch'
	/opt/axsh/openvnet/vnet/vendor/bundle/ruby/2.1.0/gems/celluloid-0.15.2/lib/celluloid/calls.rb:122:in `dispatch'
	/opt/axsh/openvnet/vnet/vendor/bundle/ruby/2.1.0/gems/celluloid-0.15.2/lib/celluloid/actor.rb:322:in `block in handle_message'
	/opt/axsh/openvnet/vnet/vendor/bundle/ruby/2.1.0/gems/celluloid-0.15.2/lib/celluloid/actor.rb:416:in `block in task'
	/opt/axsh/openvnet/vnet/vendor/bundle/ruby/2.1.0/gems/celluloid-0.15.2/lib/celluloid/tasks.rb:55:in `block in initialize'
	/opt/axsh/openvnet/vnet/vendor/bundle/ruby/2.1.0/gems/celluloid-0.15.2/lib/celluloid/tasks/task_fiber.rb:13:in `block in create'
```

