### PR TITLE
Vnctl remove httparty

### DIFF
--- a/deployment/conf_files/etc/openvnet/vnctl.conf
+++ b/deployment/conf_files/etc/openvnet/vnctl.conf
@@ -1,3 +1,5 @@
+# webapi_protocol 'http'
 # webapi_uri  '127.0.0.1'
 # webapi_port '9090'
+# webapi_version '1.0'
 # output_format 'yml'

--- a/vnctl/Gemfile
+++ b/vnctl/Gemfile
@@ -1,5 +1,4 @@
 source 'http://rubygems.org'
 
 gem 'thor'
-gem 'httparty'
 gem 'fuguta'

--- a/vnctl/Gemfile.lock
+++ b/vnctl/Gemfile.lock
@@ -2,11 +2,6 @@ GEM
   remote: http://rubygems.org/
   specs:
     fuguta (1.0.2)
-    httparty (0.11.0)
-      multi_json (~> 1.0)
-      multi_xml (>= 0.5.2)
-    multi_json (1.8.0)
-    multi_xml (0.5.5)
     thor (0.18.1)
 
 PLATFORMS
@@ -14,5 +9,4 @@ PLATFORMS
 
 DEPENDENCIES
   fuguta
-  httparty
   thor

--- a/vnctl/lib/vnctl.rb
+++ b/vnctl/lib/vnctl.rb
@@ -1,13 +1,8 @@
 # -*- coding: utf-8 -*-
 
-require 'httparty'
+require 'net/http'
 
 module Vnctl
-
-  def self.conf
-    @conf
-  end
-
   autoload :WebApi, 'vnctl/webapi'
 
   module Cli
@@ -31,5 +26,13 @@ module Vnctl
 
   module Configuration
     autoload :Vnctl, 'vnctl/configuration/vnctl'
+  end
+
+  def self.conf
+    @conf
+  end
+
+  def self.webapi
+    @webapi ||= Vnctl::WebApi.new
   end
 end

--- a/vnctl/lib/vnctl/cli/datapath.rb
+++ b/vnctl/lib/vnctl/cli/datapath.rb
@@ -3,7 +3,7 @@
 module Vnctl::Cli
   class Datapath < Base
     namespace :datapaths
-    api_suffix "/api/datapaths"
+    api_suffix "datapaths"
 
     add_modify_shared_options {
       option_display_name

--- a/vnctl/lib/vnctl/cli/dns_service.rb
+++ b/vnctl/lib/vnctl/cli/dns_service.rb
@@ -3,7 +3,7 @@
 module Vnctl::Cli
   class DnsService < Base
     namespace :dns_services
-    api_suffix "/api/dns_services"
+    api_suffix "dns_services"
 
     add_modify_shared_options {
       option :public_dns, :type => :string, :desc => "Public DNS Server addresses(separated by `.`)."

--- a/vnctl/lib/vnctl/cli/interface.rb
+++ b/vnctl/lib/vnctl/cli/interface.rb
@@ -3,7 +3,7 @@
 module Vnctl::Cli
   class Interface < Base
     namespace :interfaces
-    api_suffix "/api/interfaces"
+    api_suffix "interfaces"
 
     add_modify_shared_options {
       option :ingress_filtering_enabled, :type => :boolean,

--- a/vnctl/lib/vnctl/cli/ip_lease.rb
+++ b/vnctl/lib/vnctl/cli/ip_lease.rb
@@ -3,7 +3,7 @@
 module Vnctl::Cli
   class IpLease < Base
     namespace :ip_leases
-    api_suffix "/api/ip_leases"
+    api_suffix "ip_leases"
 
     add_modify_shared_options {
       option :network_uuid, :type => :string, :desc => "The network to lease this ip in."

--- a/vnctl/lib/vnctl/cli/ip_range_group.rb
+++ b/vnctl/lib/vnctl/cli/ip_range_group.rb
@@ -3,7 +3,7 @@
 module Vnctl::Cli
   class IpRangeGroup < Base
     namespace :ip_range_groups
-    api_suffix "/api/ip_range_groups"
+    api_suffix "ip_range_groups"
 
     add_modify_shared_options {
       option :allocation_type, :type => :string, :desc => "The way your ip addresses are going to be allocated."

--- a/vnctl/lib/vnctl/cli/lease_policies.rb
+++ b/vnctl/lib/vnctl/cli/lease_policies.rb
@@ -3,7 +3,7 @@
 module Vnctl::Cli
   class LeasePolicy < Base
     namespace :lease_policies
-    api_suffix "/api/lease_policies"
+    api_suffix "lease_policies"
 
     add_modify_shared_options {
       option :mode, :type => :string, :desc => "The mode for this lease policy. (reserved for future use)"

--- a/vnctl/lib/vnctl/cli/mac_lease.rb
+++ b/vnctl/lib/vnctl/cli/mac_lease.rb
@@ -3,7 +3,7 @@
 module Vnctl::Cli
   class MacLease < Base
     namespace :mac_leases
-    api_suffix "/api/mac_leases"
+    api_suffix "mac_leases"
 
     add_modify_shared_options {
       option_uuid

--- a/vnctl/lib/vnctl/cli/network.rb
+++ b/vnctl/lib/vnctl/cli/network.rb
@@ -3,7 +3,7 @@
 module Vnctl::Cli
   class Network < Base
     namespace :networks
-    api_suffix "/api/networks"
+    api_suffix "networks"
 
     add_modify_shared_options {
       option_display_name

--- a/vnctl/lib/vnctl/cli/network_service.rb
+++ b/vnctl/lib/vnctl/cli/network_service.rb
@@ -3,7 +3,7 @@
 module Vnctl::Cli
   class NetworkService < Base
     namespace :network_services
-    api_suffix "/api/network_services"
+    api_suffix "network_services"
 
     add_modify_shared_options {
       option_display_name

--- a/vnctl/lib/vnctl/cli/route.rb
+++ b/vnctl/lib/vnctl/cli/route.rb
@@ -3,7 +3,7 @@
 module Vnctl::Cli
   class Route < Base
     namespace :routes
-    api_suffix "/api/routes"
+    api_suffix "routes"
 
     add_modify_shared_options {
       option :interface_uuid, :type => :string, :desc => "Interface uuid for this route."

--- a/vnctl/lib/vnctl/cli/route_link.rb
+++ b/vnctl/lib/vnctl/cli/route_link.rb
@@ -3,7 +3,7 @@
 module Vnctl::Cli
   class RouteLink < Base
     namespace :route_links
-    api_suffix "/api/route_links"
+    api_suffix "route_links"
 
     add_modify_shared_options {
       option :mac_address, :type => :string, :required => true,

--- a/vnctl/lib/vnctl/cli/security_group.rb
+++ b/vnctl/lib/vnctl/cli/security_group.rb
@@ -3,7 +3,7 @@
 module Vnctl::Cli
   class SecurityGroup < Base
     namespace :security_groups
-    api_suffix "/api/security_groups"
+    api_suffix "security_groups"
 
     add_modify_shared_options {
       option_display_name

--- a/vnctl/lib/vnctl/cli/translation.rb
+++ b/vnctl/lib/vnctl/cli/translation.rb
@@ -3,7 +3,7 @@
 module Vnctl::Cli
   class Translation < Base
     namespace :translations
-    api_suffix "/api/translations"
+    api_suffix "translations"
 
     add_modify_shared_options {
       option :interface_uuid, :type => :string, :desc => "This interface uuid for this translation."

--- a/vnctl/lib/vnctl/cli/vlan_translation.rb
+++ b/vnctl/lib/vnctl/cli/vlan_translation.rb
@@ -3,7 +3,7 @@
 module Vnctl::Cli
   class VlanTranslation < Base
     namespace :vlan_translations
-    api_suffix "/api/vlan_translations"
+    api_suffix "vlan_translations"
 
     add_modify_shared_options {
       option :translation_uuid, :type => :string, :desc => "The translation uuid for this vlan translation."

--- a/vnctl/lib/vnctl/configuration/vnctl.rb
+++ b/vnctl/lib/vnctl/configuration/vnctl.rb
@@ -4,6 +4,7 @@ module Vnctl::Configuration
   class Vnctl < Fuguta::Configuration
     param :webapi_uri, :default => '127.0.0.1'
     param :webapi_port, :default => 9090
+    param :webapi_version, :default => '1.0'
     param :output_format, :default => 'yml'
 
     def validate(errors)

--- a/vnctl/lib/vnctl/configuration/vnctl.rb
+++ b/vnctl/lib/vnctl/configuration/vnctl.rb
@@ -2,10 +2,10 @@
 
 module Vnctl::Configuration
   class Vnctl < Fuguta::Configuration
+    param :webapi_protocol, :default => 'http'
     param :webapi_uri, :default => '127.0.0.1'
     param :webapi_port, :default => 9090
     param :webapi_version, :default => '1.0'
-    param :webapi_protocol, :default => 'http'
     param :output_format, :default => 'yml'
 
     def validate(errors)

--- a/vnctl/lib/vnctl/configuration/vnctl.rb
+++ b/vnctl/lib/vnctl/configuration/vnctl.rb
@@ -5,6 +5,7 @@ module Vnctl::Configuration
     param :webapi_uri, :default => '127.0.0.1'
     param :webapi_port, :default => 9090
     param :webapi_version, :default => '1.0'
+    param :webapi_protocol, :default => 'http'
     param :output_format, :default => 'yml'
 
     def validate(errors)

--- a/vnctl/lib/vnctl/webapi.rb
+++ b/vnctl/lib/vnctl/webapi.rb
@@ -3,14 +3,14 @@
 module Vnctl
   class WebApi
     def initialize
-      @webapi_uri = Vnctl.conf.webapi_uri
-      @webapi_port = Vnctl.conf.webapi_port.to_i
-      @webapi_version = Vnctl.conf.webapi_version
-      @webapi_protocol = Vnctl.conf.webapi_protocol
-      @output_format = Vnctl.conf.output_format
+      @conf = Vnctl.conf
 
-      @webapi_full_uri = "%s://%s:%s/api/%s" %
-        [@webapi_protocol, @webapi_uri, @webapi_port, @webapi_version]
+      @output_format = @conf.output_format
+
+      @webapi_full_uri = "%s://%s:%s/api/%s" % [@conf.webapi_protocol,
+                                                @conf.webapi_uri,
+                                                @conf.webapi_port,
+                                                @conf.webapi_version]
     end
 
     def send_request(verb, suffix, params = nil)

--- a/vnctl/lib/vnctl/webapi.rb
+++ b/vnctl/lib/vnctl/webapi.rb
@@ -2,7 +2,43 @@
 
 module Vnctl
   class WebApi
-    include HTTParty
-    base_uri "#{Vnctl.conf.webapi_uri}:#{Vnctl.conf.webapi_port}"
+    def initialize
+      @webapi_uri = Vnctl.conf.webapi_uri
+      @webapi_port = Vnctl.conf.webapi_port.to_i
+      @webapi_version = Vnctl.conf.webapi_version
+      @output_format = Vnctl.conf.output_format
+
+      @webapi_full_uri = "#{@webapi_uri}/api/#{@webapi_version}"
+    end
+
+    def send_request(verb, suffix, params = nil)
+      uri = URI::HTTP.build(host: @webapi_full_uri,
+                            path: "#{suffix}.#{@output_format}",
+                            port: @webapi_port)
+
+      uri.query = URI.encode_www_form(params) if params
+
+      p uri
+      Net::HTTP.start(uri.host, uri.port) do |http|
+        request = verb.new(uri.request_uri)
+        http.request(request)
+      end
+    end
+
+    def post(suffix, params = nil)
+      send_request(Net::HTTP::Post, suffix, params)
+    end
+
+    def get(suffix, params = nil)
+      send_request(Net::HTTP::Get, suffix, params)
+    end
+
+    def put(suffix, params = nil)
+      send_request(Net::HTTP::Put, suffix, params)
+    end
+
+    def delete(suffix, params = nil)
+      send_request(Net::HTTP::Delete, suffix, params)
+    end
   end
 end

--- a/vnctl/lib/vnctl/webapi.rb
+++ b/vnctl/lib/vnctl/webapi.rb
@@ -9,7 +9,8 @@ module Vnctl
       @webapi_protocol = Vnctl.conf.webapi_protocol
       @output_format = Vnctl.conf.output_format
 
-      @webapi_full_uri = "#{@webapi_protocol}://#{@webapi_uri}:#{@webapi_port}/api/#{@webapi_version}"
+      @webapi_full_uri = "%s://%s:%s/api/%s" %
+        [@webapi_protocol, @webapi_uri, @webapi_port, @webapi_version]
     end
 
     def send_request(verb, suffix, params = nil)

--- a/vnctl/lib/vnctl/webapi.rb
+++ b/vnctl/lib/vnctl/webapi.rb
@@ -6,23 +6,23 @@ module Vnctl
       @webapi_uri = Vnctl.conf.webapi_uri
       @webapi_port = Vnctl.conf.webapi_port.to_i
       @webapi_version = Vnctl.conf.webapi_version
+      @webapi_protocol = Vnctl.conf.webapi_protocol
       @output_format = Vnctl.conf.output_format
 
-      @webapi_full_uri = "#{@webapi_uri}/api/#{@webapi_version}"
+      @webapi_full_uri = "#{@webapi_protocol}://#{@webapi_uri}:#{@webapi_port}/api/#{@webapi_version}"
     end
 
     def send_request(verb, suffix, params = nil)
-      uri = URI::HTTP.build(host: @webapi_full_uri,
-                            path: "#{suffix}.#{@output_format}",
-                            port: @webapi_port)
+      uri = URI("#{@webapi_full_uri}/#{suffix}.#{@output_format}")
 
       uri.query = URI.encode_www_form(params) if params
 
-      p uri
-      Net::HTTP.start(uri.host, uri.port) do |http|
+      response = Net::HTTP.start(uri.host, uri.port) do |http|
         request = verb.new(uri.request_uri)
         http.request(request)
       end
+
+      response.body
     end
 
     def post(suffix, params = nil)


### PR DESCRIPTION
I miss programming a bit so I decided to quickly remove the httparty library from vnctl. Ruby has a perfectly usable HTTP class in the standard library and less dependencies is better.