### PR TITLE
Set vendor name for .rpm

### DIFF
--- a/deployment/packagebuild/packages.d/vnet/openvnet-common/recipe.rb
+++ b/deployment/packagebuild/packages.d/vnet/openvnet-common/recipe.rb
@@ -4,6 +4,7 @@ class OpenvnetCommon < FPM::Cookery::Recipe
   homepage 'https://github.com/axsh/openvnet/'
   version (ENV['BUILD_TIME'] || Time.now.strftime('%Y%m%d%H%M%S')) + (ENV['GIT_COMMIT'] ? "git#{ENV['GIT_COMMIT'].slice(0, 7)}" : "spot")
   source   File.expand_path("../../../../../", File.dirname(__FILE__)), :with => :local_path
+  vendor 'axsh'
 
   depends *%w(
     zeromq3-devel

--- a/deployment/packagebuild/packages.d/vnet/openvnet-vna/recipe.rb
+++ b/deployment/packagebuild/packages.d/vnet/openvnet-vna/recipe.rb
@@ -6,6 +6,7 @@ class OpenvnetVna < FPM::Cookery::Recipe
   #source   'https://github.com/axsh/openvnet/', :with => :git
   source   File.expand_path("../../../../../", File.dirname(__FILE__)), :with => :local_path
   arch 'all'
+  vendor 'axsh'
   depends *%w(
     libpcap-devel
     openvswitch

--- a/deployment/packagebuild/packages.d/vnet/openvnet-vnctl/recipe.rb
+++ b/deployment/packagebuild/packages.d/vnet/openvnet-vnctl/recipe.rb
@@ -5,6 +5,7 @@ class OpenvnetVnctl < FPM::Cookery::Recipe
   version (ENV['BUILD_TIME'] || Time.now.strftime('%Y%m%d%H%M%S')) + (ENV['GIT_COMMIT'] ? "git#{ENV['GIT_COMMIT'].slice(0, 7)}" : "spot")
   source   File.expand_path("../../../../../", File.dirname(__FILE__)), :with => :local_path
   arch 'all'
+  vendor 'axsh'
 
   depends 'openvnet-ruby'
 

--- a/deployment/packagebuild/packages.d/vnet/openvnet-vnmgr/recipe.rb
+++ b/deployment/packagebuild/packages.d/vnet/openvnet-vnmgr/recipe.rb
@@ -6,6 +6,7 @@ class OpenvnetVnmgr < FPM::Cookery::Recipe
   #source   'https://github.com/axsh/openvnet/', :with => :git
   source   File.expand_path("../../../../../", File.dirname(__FILE__)), :with => :local_path
   arch 'all'
+  vendor 'axsh'
   depends *%w(
     redis
     mysql-server

--- a/deployment/packagebuild/packages.d/vnet/openvnet-webapi/recipe.rb
+++ b/deployment/packagebuild/packages.d/vnet/openvnet-webapi/recipe.rb
@@ -5,6 +5,7 @@ class OpenvnetWebapi < FPM::Cookery::Recipe
   version (ENV['BUILD_TIME'] || Time.now.strftime('%Y%m%d%H%M%S')) + (ENV['GIT_COMMIT'] ? "git#{ENV['GIT_COMMIT'].slice(0, 7)}" : "spot")
   source   File.expand_path("../../../../../", File.dirname(__FILE__)), :with => :local_path
   arch 'all'
+  vendor 'axsh'
   depends *%w(
     openvnet-common
   )

--- a/deployment/packagebuild/packages.d/vnet/openvnet/recipe.rb
+++ b/deployment/packagebuild/packages.d/vnet/openvnet/recipe.rb
@@ -5,6 +5,7 @@ class Openvnet < FPM::Cookery::Recipe
   version (ENV['BUILD_TIME'] || Time.now.strftime('%Y%m%d%H%M%S')) + (ENV['GIT_COMMIT'] ? "git#{ENV['GIT_COMMIT'].slice(0, 7)}" : "spot")
   source '', :with => :noop
   arch 'all'
+  vendor 'axsh'
   depends *%w(
     openvnet-vnmgr
     openvnet-webapi


### PR DESCRIPTION
Since FPM sets "fpm0" as the default vendor ID to package tool chain, we used to see the package file name like:

```
openvnet-common-20150519135811gite392f33.fpm0-1.x86_64.rpm
```

It is preferable to see correct vendor ID on the file name and the rpm attribute.

```
openvnet-common-20150519135811gite392f33.axsh-1.x86_64.rpm
```