### PR TITLE
Fix trema thread creation to avoid any Celluloid Thread extensions as…

### DIFF
--- a/vnet/lib/vnet/node_modules/service_openflow.rb
+++ b/vnet/lib/vnet/node_modules/service_openflow.rb
@@ -91,7 +91,9 @@ module Vnet
         @controller.init_trema
         @controller.open_trema_tasks
 
-        @controller.trema_thread = Thread.new {
+        # Make sure we use the default Thread instead of any Celluloid
+        # extensions.
+        @controller.trema_thread = ::Thread.new {
           begin
             @controller.run_no_init!
           rescue Exception => e


### PR DESCRIPTION
… that makes celluloid new method think the thread is a valid Celluloid capable thread.

```
17:45:10 --------------------------------------------------
17:45:10 simple: success
17:45:10 router_v2v: success
17:45:10 router_p2v: success
17:45:10 event: success
17:45:10 service: success
17:45:10 secg: success
17:45:10 secg_reference: success
17:45:10 edge: failure
17:45:10 --------------------------------------------------
```