### PR TITLE
Add all possible routes to router_p2v test

### DIFF
--- a/integration_test/lib/vnspec/spec/router_p2v_spec.rb
+++ b/integration_test/lib/vnspec/spec/router_p2v_spec.rb
@@ -2,55 +2,176 @@
 require_relative "spec_helper"
 
 describe "router_p2v" do
-  describe "pnet" do
-    context "mac2mac" do
-      it "reachable to pnet" do
+  describe "public to public" do
+    context "vm1 to vm3" do
+      it "reachable" do
         expect(vm1).to be_reachable_to(vm3)
+      end
+    end
+    context "vm3 to vm1" do
+      it "reachable" do
         expect(vm3).to be_reachable_to(vm1)
       end
-
-      it "reachable to vnet" do
+    end
+  end
+  
+  describe "public to 102" do
+    describe "vm1 to vm2" do
+      it "reachable" do
         expect(vm1).to be_reachable_to(vm2)
+      end
+    end
+    describe "vm1 to vm4" do
+      it "reachable" do
         expect(vm1).to be_reachable_to(vm4)
+      end
+    end
+    describe "vm1 to vm6" do
+      it "reachable" do
+        expect(vm1).to be_reachable_to(vm6)
+      end
+    end
+    describe "vm3 to vm2" do
+      it "reachable" do
         expect(vm3).to be_reachable_to(vm2)
+      end
+    end
+    describe "vm3 to vm4" do
+      it "reachable" do
         expect(vm3).to be_reachable_to(vm4)
       end
     end
-
-    context "tunnel" do
-      it "reachable to vnet" do
-        expect(vm1).to be_reachable_to(vm6)
+    describe "vm3 to vm6" do
+      it "reachable" do
         expect(vm3).to be_reachable_to(vm6)
       end
     end
   end
 
-  describe "vnet" do
-    context "mac2mac" do
-      it "reachable to pnet" do
+  describe "public to 101" do
+    describe "vm1 to vm5" do
+      it "reachable" do
+        expect(vm1).to be_reachable_to(vm5)
+      end
+    end
+    describe "vm3 to vm5" do
+      it "reachable" do
+        expect(vm3).to be_reachable_to(vm5)
+      end
+    end
+  end
+
+  describe "102 to public" do
+    describe "vm2 to vm1" do
+      it "reachable" do
         expect(vm2).to be_reachable_to(vm1)
+      end
+    end
+    describe "vm2 to vm3" do
+      it "reachable" do
         expect(vm2).to be_reachable_to(vm3)
+      end
+    end
+    describe "vm4 to vm1" do
+      it "reachable" do
         expect(vm4).to be_reachable_to(vm1)
+      end
+    end
+    describe "vm4 to vm3" do
+      it "reachable" do
         expect(vm4).to be_reachable_to(vm3)
       end
+    end
+    describe "vm6 to vm1" do
+      it "reachable" do
+        expect(vm6).to be_reachable_to(vm1)
+      end
+    end
+    describe "vm6 to vm3" do
+      it "reachable" do
+        expect(vm6).to be_reachable_to(vm3)
+      end
+    end
+  end
 
-      it "reachable to vnet" do
+  describe "102 to 102" do
+    describe "vm2 to vm4" do
+      it "reachable" do
         expect(vm2).to be_reachable_to(vm4)
+      end
+    end
+    describe "vm2 to vm6" do
+      it "reachable" do
+        expect(vm2).to be_reachable_to(vm6)
+      end
+    end
+    describe "vm4 to vm2" do
+      it "reachable" do
         expect(vm4).to be_reachable_to(vm2)
       end
     end
-
-    context "tunnel" do
-      it "reachable to pnet" do
-        expect(vm6).to be_reachable_to(vm1)
-        expect(vm6).to be_reachable_to(vm3)
-      end
-
-      it "reachable to vnet" do
-        expect(vm2).to be_reachable_to(vm6)
+    describe "vm4 to vm6" do
+      it "reachable" do
         expect(vm4).to be_reachable_to(vm6)
-        expect(vm6).to be_reachable_to(vm2)
+      end
+    end
+    describe "vm6 to vm2" do
+      it "reachable" do
+        expect(vm6).to be_reachable_to(vm6)
+      end
+    end
+    describe "vm6 to vm4" do
+      it "reachable" do
         expect(vm6).to be_reachable_to(vm4)
+      end
+    end
+  end
+
+  describe "102 to 101" do
+    describe "vm2 to vm5" do
+      it "reachable" do
+        expect(vm2).to be_reachable_to(vm5)
+      end
+    end
+    describe "vm4 to vm5" do
+      it "reachable" do
+        expect(vm4).to be_reachable_to(vm5)
+      end
+    end
+    describe "vm6 to vm5" do
+      it "reachable" do
+        expect(vm6).to be_reachable_to(vm5)
+      end
+    end
+  end
+
+  describe "101 to public" do
+    describe "vm5 to vm1" do
+      it "reachable" do
+        expect(vm5).to be_reachable_to(vm1)
+      end
+    end
+    describe "vm5 to vm3" do
+      it "reachable" do
+        expect(vm5).to be_reachable_to(vm3)
+      end
+    end
+  end
+
+  describe "101 to 102" do
+    describe "vm5 to vm2" do
+      it "reachable" do
+        expect(vm5).to be_reachable_to(vm2)
+      end
+    end
+    describe "vm5 to vm4" do
+      it "reachable" do
+        expect(vm5).to be_reachable_to(vm4)
+      end
+    end
+    describe "vm5 to vm6" do
+      it "reachable" do
+        expect(vm5).to be_reachable_to(vm6)
       end
     end
   end


### PR DESCRIPTION
Test now contains all the possible routes between the different VM's to give a more detailed test result of the environment