### PR TITLE
Feature event control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * `Fixed` Code cleanup and minor bug fixes in datapath manager.
 
+* `Fixed` An issue where events could get processed before managers were initialized, causing race conditions.
+
 ## [0.7] - 2015-06-04
 
 The first numbered OpenVNet release.

--- a/vnet/lib/vnet/core/active_interface_manager.rb
+++ b/vnet/lib/vnet/core/active_interface_manager.rb
@@ -7,6 +7,7 @@ module Vnet::Core
     #
     # Events:
     #
+    event_handler_default_drop_all
 
     subscribe_event ACTIVE_INTERFACE_INITIALIZED, :load_item
     subscribe_event ACTIVE_INTERFACE_UNLOAD_ITEM, :unload_item

--- a/vnet/lib/vnet/core/datapath_manager.rb
+++ b/vnet/lib/vnet/core/datapath_manager.rb
@@ -8,6 +8,8 @@ module Vnet::Core
     #
     # Events:
     #
+    event_handler_default_drop_all
+
     subscribe_event DATAPATH_INITIALIZED, :load_item
     subscribe_event DATAPATH_UNLOAD_ITEM, :unload_item
     subscribe_event DATAPATH_CREATED_ITEM, :created_item

--- a/vnet/lib/vnet/core/interface_manager.rb
+++ b/vnet/lib/vnet/core/interface_manager.rb
@@ -9,6 +9,8 @@ module Vnet::Core
     #
     # Events:
     #
+    event_handler_default_drop_all
+
     subscribe_event INTERFACE_INITIALIZED, :load_item
     subscribe_event INTERFACE_UNLOAD_ITEM, :unload_item
     subscribe_event INTERFACE_CREATED_ITEM, :created_item

--- a/vnet/lib/vnet/core/interface_port_manager.rb
+++ b/vnet/lib/vnet/core/interface_port_manager.rb
@@ -9,6 +9,7 @@ module Vnet::Core
     #
     # Events:
     #
+    event_handler_default_drop_all
 
     subscribe_event INTERFACE_PORT_INITIALIZED, :load_item
     subscribe_event INTERFACE_PORT_UNLOAD_ITEM, :unload_item

--- a/vnet/lib/vnet/core/network_manager.rb
+++ b/vnet/lib/vnet/core/network_manager.rb
@@ -11,6 +11,7 @@ module Vnet::Core
     #
     # Events:
     #
+    event_handler_default_drop_all
     
     # Networks have no created item event as they always get loaded
     # when used by other managers.

--- a/vnet/lib/vnet/core/route_manager.rb
+++ b/vnet/lib/vnet/core/route_manager.rb
@@ -9,6 +9,7 @@ module Vnet::Core
     #
     # Events:
     #
+    event_handler_default_drop_all
 
     subscribe_event ROUTE_INITIALIZED, :load_item
     subscribe_event ROUTE_UNLOAD_ITEM, :unload_item

--- a/vnet/lib/vnet/core/router_manager.rb
+++ b/vnet/lib/vnet/core/router_manager.rb
@@ -7,6 +7,8 @@ module Vnet::Core
     #
     # Events:
     #
+    event_handler_default_drop_all
+
     subscribe_event ROUTER_INITIALIZED, :load_item
     subscribe_event ROUTER_UNLOAD_ITEM, :unload_item
     subscribe_event ROUTER_CREATED_ITEM, :created_item

--- a/vnet/lib/vnet/core/service_manager.rb
+++ b/vnet/lib/vnet/core/service_manager.rb
@@ -9,6 +9,8 @@ module Vnet::Core
     #
     # Events:
     #
+    event_handler_default_drop_all
+
     subscribe_event SERVICE_INITIALIZED, :load_item
     subscribe_event SERVICE_UNLOAD_ITEM, :unload_item
     subscribe_event SERVICE_CREATED_ITEM, :created_item

--- a/vnet/lib/vnet/core/translation_manager.rb
+++ b/vnet/lib/vnet/core/translation_manager.rb
@@ -10,6 +10,8 @@ module Vnet::Core
     #
     # Events:
     #
+    event_handler_default_drop_all
+
     subscribe_event TRANSLATION_INITIALIZED, :load_item
     subscribe_event TRANSLATION_UNLOAD_ITEM, :unload_item
     subscribe_event TRANSLATION_CREATED_ITEM, :created_item

--- a/vnet/lib/vnet/core/tunnel_manager.rb
+++ b/vnet/lib/vnet/core/tunnel_manager.rb
@@ -9,6 +9,8 @@ module Vnet::Core
     #
     # Events:
     #
+    event_handler_default_drop_all
+
     subscribe_event REMOVED_TUNNEL, :unload
     subscribe_event INITIALIZED_TUNNEL, :install_item
 

--- a/vnet/lib/vnet/event/notifications.rb
+++ b/vnet/lib/vnet/event/notifications.rb
@@ -38,6 +38,29 @@ module Vnet::Event
     end
 
     module ClassMethods
+      # TODO: Add a subscribe event that gets the item, or might even
+      # retrieve the item from the database if not present.
+
+      def subscribe_event(event_name, method = nil, options = {})
+        self.event_definitions[event_name] = { method: method, options: options }
+      end
+
+      def event_handler_default_state
+        @event_handler_default_state ||= :active
+      end
+
+      def event_handler_default_active
+        @event_handler_default_state = :active
+      end
+
+      def event_handler_default_drop_all
+        @event_handler_default_state = :drop_all
+      end
+
+      def event_handler_default_queue_only
+        @event_handler_default_state = :queue_only
+      end
+
       def event_definitions
         @event_definitions ||= {}
       end
@@ -57,22 +80,17 @@ module Vnet::Event
 
         event_method
       end
-
-      # TODO: Add a subscribe event that gets the item, or might even
-      # retrieve the item from the database if not present.
-
-      def subscribe_event(event_name, method = nil, options = {})
-        self.event_definitions[event_name] = { method: method, options: options }
-      end
     end
 
     module Initializer
       def initialize(*args, &block)
-        @event_handler_state = :active
+        @event_handler_state = self.class.event_handler_default_state
         @event_queues = {}
         @queue_statuses = {}
 
         super
+
+        # debug "#{self.class.name} initialized with event handler state #{@event_handler_state}"
 
         subscribe_events
       end

--- a/vnet/lib/vnet/event/notifications.rb
+++ b/vnet/lib/vnet/event/notifications.rb
@@ -43,13 +43,17 @@ module Vnet::Event
     def event_handler_active
       @event_handler_state = :active
 
-      # Call queue handler.
+      @event_queues.keys.each { |queue_id|
+        event_handler_start_queue(queue_id)
+      }
     end
 
     def event_handler_drop_all
       @event_handler_state = :drop_all
 
-      # Clear queue.
+      # The @queue_statuses should be cleared when all fibers in
+      # 'event_handler_process_queue' finish.
+      @event_queues.clear
     end
 
     def event_handler_queue_only
@@ -102,6 +106,9 @@ module Vnet::Event
     end
 
     def event_handler_process_queue(queue_id)
+      # TODO: Don't retrieve the queue needlessly, however do keep in
+      # mind the states.
+
       while @event_queues[queue_id].present?
         event_queue = @event_queues[queue_id]
         event = event_queue.shift

--- a/vnet/lib/vnet/event/notifications.rb
+++ b/vnet/lib/vnet/event/notifications.rb
@@ -68,7 +68,7 @@ module Vnet::Event
 
     module Initializer
       def initialize(*args, &block)
-        @event_handler_state = :active # Test with :drop_all
+        @event_handler_state = :active
         @event_queues = {}
         @queue_statuses = {}
 
@@ -120,7 +120,10 @@ module Vnet::Event
     # Event handling:
     #
 
+    # TODO: Rename this to something more meaningful such as queue event.
     def handle_event(event_name, params)
+      return if @event_handler_state == :drop_all
+
       #debug "handle event: #{event_name} params: #{params.inspect}}"
 
       queue_id = params[:id]
@@ -137,7 +140,6 @@ module Vnet::Event
       end
 
       event_queue << { event_name: event_name, params: params.dup }
-
       event_handler_start_queue(queue_id)
     end
 
@@ -148,6 +150,7 @@ module Vnet::Event
     private
 
     def event_handler_start_queue(queue_id)
+      return if @event_handler_state != :active
       return if @queue_statuses[queue_id]
 
       @queue_statuses[queue_id] = true

--- a/vnet/lib/vnet/event/notifications.rb
+++ b/vnet/lib/vnet/event/notifications.rb
@@ -90,6 +90,7 @@ module Vnet::Event
 
         super
 
+        # Careful with this debug, it causes a yield within the initializer.
         # debug "#{self.class.name} initialized with event handler state #{@event_handler_state}"
 
         subscribe_events
@@ -207,7 +208,7 @@ module Vnet::Event
 
         __send__(event_method, event_params)
 
-        #debug "executed event: #{event_name} method: #{event_method} params: #{event_params.inspect}"
+        # debug "executed event: #{event_name} method: #{event_method} params: #{event_params.inspect}"
       end
 
     ensure

--- a/vnet/lib/vnet/event/notifications.rb
+++ b/vnet/lib/vnet/event/notifications.rb
@@ -98,13 +98,12 @@ module Vnet::Event
       return if @queue_statuses[queue_id]
 
       @queue_statuses[queue_id] = true
-      async(:fetch_queued_events, queue_id)
+      async(:event_handler_process_queue, queue_id)
     end
 
-    # TODO: Rename method and 'id'.
-    def fetch_queued_events(id)
-      while @event_queues[id].present?
-        event_queue = @event_queues[id]
+    def event_handler_process_queue(queue_id)
+      while @event_queues[queue_id].present?
+        event_queue = @event_queues[queue_id]
         event = event_queue.shift
 
         event_definition = event_definitions[event[:event_name]]
@@ -115,11 +114,11 @@ module Vnet::Event
         __send__(event_definition[:method], event[:params])
       end
 
-      @event_queues.delete(id)
+      @event_queues.delete(queue_id)
       return
 
     ensure
-      @queue_statuses.delete(id)
+      @queue_statuses.delete(queue_id)
     end
 
   end

--- a/vnet/lib/vnet/openflow/datapath.rb
+++ b/vnet/lib/vnet/openflow/datapath.rb
@@ -111,6 +111,13 @@ module Vnet::Openflow
       #
       # TODO: This should be done automatically by datapath manager
       # when it is initialized.
+      # 
+      # Since we load the host datapath here, we need to set
+      # queue-only now.
+      @dp_info.managers.each { |manager|
+        manager.event_handler_queue_only
+      }
+
       @dp_info.datapath_manager.async.retrieve(dpid: @dpid)
     end
 
@@ -179,6 +186,11 @@ module Vnet::Openflow
       # initialized.
       @dp_info.interface_port_manager.load_internal_interfaces
       @dp_info.port_manager.initialize_ports
+
+      # All managers should be initialized, allow events to execute.
+      @dp_info.managers.each { |manager|
+        manager.event_handler_active
+      }
     end
 
   end

--- a/vnet/lib/vnet/openflow/datapath.rb
+++ b/vnet/lib/vnet/openflow/datapath.rb
@@ -72,6 +72,11 @@ module Vnet::Openflow
       wait_for_unload_of_host_datapath
 
       info log_format('resetting datapath info')
+
+      @dp_info.managers.each { |manager|
+        manager.event_handler_drop_all
+      }
+
       @controller.pass_task { @controller.reset_datapath(@dpid) }
 
       return nil

--- a/vnet/spec/vnet/event/notifications_spec.rb
+++ b/vnet/spec/vnet/event/notifications_spec.rb
@@ -221,18 +221,21 @@ describe Vnet::Event::Notifications do
 
     it "enqueue event to a list identified by params[:id]" do
       manager_class.class_eval do
-        def fetch_queued_events(id)
+        def event_handler_process_queue(id)
           "do nothing"
         end
       end
 
       item_manager = manager_class.new
 
-      item_manager.db_items.push({ id: 1, name: :foo })
-      notifier.publish("item_created", id: 1)
+      item_map_1 = { id: 1, name: :foo }
+      item_map_2 = { id: 2, name: :bar }
+
+      item_manager.db_items.push(item_map_1)
+      notifier.publish("item_created", id: 1, item_map: item_map_1)
       sleep 0.01
-      item_manager.db_items.push({ id: 2, name: :bar })
-      notifier.publish("item_created", id: 2)
+      item_manager.db_items.push(item_map_2)
+      notifier.publish("item_created", id: 2, item_map: item_map_2)
       sleep 0.01
       item_manager.db_items.find{|i| i[:id] == 2}[:name] = :baz
       notifier.publish("item_updated", id: 2)


### PR DESCRIPTION
#356 

Makes sure events are dropped, and queued-only, during critical stages of bootstrap such that race-conditions during initialization won't cause issues.