### PR TITLE
update ovs version from 2.3.0 to 2.3.1.

### DIFF
--- a/deployment/packagebuild/packages.d/third_party/openvnet-openvswitch/rpmbuild.sh
+++ b/deployment/packagebuild/packages.d/third_party/openvnet-openvswitch/rpmbuild.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-ovs_version="2.3.0"
+ovs_version="2.3.1"
 
 work_dir=${WORK_DIR:-/tmp/vnet-rpmbuild}
 package_work_dir=${work_dir}/packages.d/third_party/openvnet-openvswitch


### PR DESCRIPTION
### Problem

Building Open vSwitch 2.3.0 failed on CentOS 6.6.

### Solution

Update Open vSwitch version from 2.3.0 to 2.3.1.
