### PR TITLE
Remove client ruby version requirement

### DIFF
--- a/client/ruby/README.md
+++ b/client/ruby/README.md
@@ -50,6 +50,6 @@ The version number of this gem follows the version of OpenVNet. Each number has 
 
 [OpenVNet major version].[OpenVNet minor version].[OpenVNet hotix].[vnet_api_client gem release]
 
-The vnet_api_client gem release number is added because it can some times be necessary to release hotfixes to the gem before a new version of OpenVNet is released.
+The vnet_api_client gem release number is added because it can some times be necessary to release hotfixes for the gem before a new version of OpenVNet is released.
 
 Do note that OpenVNet's versioning scheme ommits the hotfix number if it is zero. For example if you are using OpenVNet 0.8, then you should use vnet_api_client version 0.8.0.x.

--- a/client/ruby/README.md
+++ b/client/ruby/README.md
@@ -45,3 +45,11 @@ VNetAPIClient::Datapath.show_networks('dp-mypath')
 # Deletes a static address from a translation
 VNetAPIClient::Translation.remove_static_address('tr-xxxxx')
 ```
+
+The version number of this gem follows the version of OpenVNet. Each number has the following meaning:
+
+[OpenVNet major version].[OpenVNet minor version].[OpenVNet hotix].[vnet_api_client gem release]
+
+The vnet_api_client gem release number is added because it can some times be necessary to release hotfixes to the gem before a new version of OpenVNet is released.
+
+Do note that OpenVNet's versioning scheme ommits the hotfix number if it is zero. For example if you are using OpenVNet 0.8, then you should use vnet_api_client version 0.8.0.x.

--- a/client/ruby/vnet_api_client.gemspec
+++ b/client/ruby/vnet_api_client.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'vnet_api_client'
-  s.version     = '0.8'
+  s.version     = '0.8.0.2'
   s.date        = '2015-09-04'
   s.summary     = 'Ruby wrapper for OpenVNet\'s RESTful API'
   s.description = s.summary

--- a/client/ruby/vnet_api_client.gemspec
+++ b/client/ruby/vnet_api_client.gemspec
@@ -9,6 +9,4 @@ Gem::Specification.new do |s|
   s.files       = Dir.glob("{lib}/**/*") + %w(README.md)
   s.homepage    = 'http://openvnet.org'
   s.license     = 'LGPLv3'
-
-  s.required_ruby_version = '>= 2.1.1'
 end


### PR DESCRIPTION
Removed the ruby version requirement of our vnet_api_client gem. Pushed the version to 0.8.0.2 and added a version number description to the readme.