### PR TITLE
Fix ci broadcast mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * `Added` A new simple firewall feature alongside the existing security groups. Security groups will eventually be ported to use this.
 
+* `Removed` The `broadcast_mac_address` parameter in the WebAPI's datapaths endpoint. Use `mac_address` instead.
+
 * `Changed` Added a default value of `false` to all `is_deleted` flags in the database. Now OpenVNet can be used with MySQL's STRICT mode.
 
 * `Fixed` An issue where vna could retrieve network resources from vnmgr while their related resources were not fully loaded yet.

--- a/client/vnctl/lib/vnctl/cli/datapath.rb
+++ b/client/vnctl/lib/vnctl/cli/datapath.rb
@@ -16,7 +16,7 @@ module Vnctl::Cli
     define_standard_crud_commands
 
     define_relation :networks do |relation|
-      relation.option :mac_address, :type => :string,
+      relation.option :mac_address, :type => :string, :required => true,
         :desc => "The broadcast mac address for mac2mac to use in this network."
       relation.option :interface_uuid, :type => :string, :required => true,
         :desc => "The host interface uuid to use for this network."

--- a/client/vnctl/lib/vnctl/cli/datapath.rb
+++ b/client/vnctl/lib/vnctl/cli/datapath.rb
@@ -18,8 +18,6 @@ module Vnctl::Cli
     define_relation :networks do |relation|
       relation.option :mac_address, :type => :string,
         :desc => "The broadcast mac address for mac2mac to use in this network."
-      relation.option :broadcast_mac_address, :type => :string,
-        :desc => "Deprecated. Use --mac_address instead."
       relation.option :interface_uuid, :type => :string, :required => true,
         :desc => "The host interface uuid to use for this network."
     end

--- a/integration_test/dataset/base.yml
+++ b/integration_test/dataset/base.yml
@@ -84,14 +84,14 @@ datapath_networks:
   - datapath_uuid: dp-1
     network_uuid: nw-public1
     interface_uuid: if-dp1eth0
-    broadcast_mac_address: "02:00:01:aa:01:01"
+    mac_address: "02:00:01:aa:01:01"
 
   - datapath_uuid: dp-2
     network_uuid: nw-public1
     interface_uuid: if-dp2eth0
-    broadcast_mac_address: "02:00:01:bb:01:01"
+    mac_address: "02:00:01:bb:01:01"
 
   - datapath_uuid: dp-3
     network_uuid: nw-public2
     interface_uuid: if-dp3eth0
-    broadcast_mac_address: "02:00:01:cc:01:01"
+    mac_address: "02:00:01:cc:01:01"

--- a/integration_test/dataset/edge.yml
+++ b/integration_test/dataset/edge.yml
@@ -101,47 +101,47 @@ datapath_networks:
   - datapath_uuid: dp-1
     network_uuid: nw-vnet1
     interface_uuid: if-dp1eth0
-    broadcast_mac_address: "02:00:00:aa:00:01"
+    mac_address: "02:00:00:aa:00:01"
 
   - datapath_uuid: dp-1
     network_uuid: nw-vnet2
     interface_uuid: if-dp1eth0
-    broadcast_mac_address: "02:00:00:aa:00:02"
+    mac_address: "02:00:00:aa:00:02"
 
   - datapath_uuid: dp-2
     network_uuid: nw-vnet1
     interface_uuid: if-dp2eth0
-    broadcast_mac_address: "02:00:00:bb:00:01"
+    mac_address: "02:00:00:bb:00:01"
 
   - datapath_uuid: dp-2
     network_uuid: nw-vnet2
     interface_uuid: if-dp2eth0
-    broadcast_mac_address: "02:00:00:bb:00:02"
+    mac_address: "02:00:00:bb:00:02"
 
   - datapath_uuid: dp-3
     network_uuid: nw-vnet1
     interface_uuid: if-dp3eth0
-    broadcast_mac_address: "02:00:00:cc:00:01"
+    mac_address: "02:00:00:cc:00:01"
 
   - datapath_uuid: dp-3
     network_uuid: nw-vnet2
     interface_uuid: if-dp3eth0
-    broadcast_mac_address: "02:00:00:cc:00:02"
+    mac_address: "02:00:00:cc:00:02"
 
   - datapath_uuid: dp-edge
     network_uuid: nw-public1
     interface_uuid: if-edgeeth0
-    broadcast_mac_address: "02:00:01:dd:01:01"
+    mac_address: "02:00:01:dd:01:01"
 
   - datapath_uuid: dp-edge
     network_uuid: nw-vnet1
     interface_uuid: if-edgeeth0
-    broadcast_mac_address: "02:00:00:dd:00:01"
+    mac_address: "02:00:00:dd:00:01"
 
   - datapath_uuid: dp-edge
     network_uuid: nw-vnet2
     interface_uuid: if-edgeeth0
-    broadcast_mac_address: "02:00:00:dd:00:02"
+    mac_address: "02:00:00:dd:00:02"
 
 translations:
 

--- a/integration_test/dataset/edge_esxi.yml
+++ b/integration_test/dataset/edge_esxi.yml
@@ -101,47 +101,47 @@ datapath_networks:
   - datapath_uuid: dp-1
     network_uuid: nw-vnet1
     interface_uuid: if-dp1eth0
-    broadcast_mac_address: "02:00:00:aa:00:01"
+    mac_address: "02:00:00:aa:00:01"
 
   - datapath_uuid: dp-1
     network_uuid: nw-vnet2
     interface_uuid: if-dp1eth0
-    broadcast_mac_address: "02:00:00:aa:00:02"
+    mac_address: "02:00:00:aa:00:02"
 
   - datapath_uuid: dp-2
     network_uuid: nw-vnet1
     interface_uuid: if-dp2eth0
-    broadcast_mac_address: "02:00:00:bb:00:01"
+    mac_address: "02:00:00:bb:00:01"
 
   - datapath_uuid: dp-2
     network_uuid: nw-vnet2
     interface_uuid: if-dp2eth0
-    broadcast_mac_address: "02:00:00:bb:00:02"
+    mac_address: "02:00:00:bb:00:02"
 
   - datapath_uuid: dp-3
     network_uuid: nw-vnet1
     interface_uuid: if-dp3eth0
-    broadcast_mac_address: "02:00:00:cc:00:01"
+    mac_address: "02:00:00:cc:00:01"
 
   - datapath_uuid: dp-3
     network_uuid: nw-vnet2
     interface_uuid: if-dp3eth0
-    broadcast_mac_address: "02:00:00:cc:00:02"
+    mac_address: "02:00:00:cc:00:02"
 
   - datapath_uuid: dp-edgeesxi
     network_uuid: nw-public1
     interface_uuid: if-edgeeth0
-    broadcast_mac_address: "02:00:01:dd:01:01"
+    mac_address: "02:00:01:dd:01:01"
 
   - datapath_uuid: dp-edgeesxi
     network_uuid: nw-vnet1
     interface_uuid: if-edgeeth0
-    broadcast_mac_address: "02:00:00:dd:00:01"
+    mac_address: "02:00:00:dd:00:01"
 
   - datapath_uuid: dp-edgeesxi
     network_uuid: nw-vnet2
     interface_uuid: if-edgeeth0
-    broadcast_mac_address: "02:00:00:dd:00:02"
+    mac_address: "02:00:00:dd:00:02"
 
 translations:
 

--- a/integration_test/dataset/event.yml
+++ b/integration_test/dataset/event.yml
@@ -101,32 +101,32 @@ datapath_networks:
   - datapath_uuid: dp-1
     network_uuid: nw-vnet1
     interface_uuid: if-dp1eth0
-    broadcast_mac_address: "02:00:00:aa:00:01"
+    mac_address: "02:00:00:aa:00:01"
 
   - datapath_uuid: dp-1
     network_uuid: nw-vnet2
     interface_uuid: if-dp1eth0
-    broadcast_mac_address: "02:00:00:aa:00:02"
+    mac_address: "02:00:00:aa:00:02"
 
   - datapath_uuid: dp-2
     network_uuid: nw-vnet1
     interface_uuid: if-dp2eth0
-    broadcast_mac_address: "02:00:00:bb:00:01"
+    mac_address: "02:00:00:bb:00:01"
 
   - datapath_uuid: dp-2
     network_uuid: nw-vnet2
     interface_uuid: if-dp2eth0
-    broadcast_mac_address: "02:00:00:bb:00:02"
+    mac_address: "02:00:00:bb:00:02"
 
   - datapath_uuid: dp-3
     network_uuid: nw-vnet1
     interface_uuid: if-dp3eth0
-    broadcast_mac_address: "02:00:00:cc:00:01"
+    mac_address: "02:00:00:cc:00:01"
 
   - datapath_uuid: dp-3
     network_uuid: nw-vnet2
     interface_uuid: if-dp3eth0
-    broadcast_mac_address: "02:00:00:cc:00:02"
+    mac_address: "02:00:00:cc:00:02"
 
 route_links:
 

--- a/integration_test/dataset/filter.yml
+++ b/integration_test/dataset/filter.yml
@@ -83,32 +83,32 @@ datapath_networks:
   - datapath_uuid: dp-1
     network_uuid: nw-vnet1
     interface_uuid: if-dp1eth0
-    broadcast_mac_address: "02:00:00:aa:00:01"
+    mac_address: "02:00:00:aa:00:01"
 
   - datapath_uuid: dp-1
     network_uuid: nw-vnet2
     interface_uuid: if-dp1eth0
-    broadcast_mac_address: "02:00:00:aa:00:02"
+    mac_address: "02:00:00:aa:00:02"
 
   - datapath_uuid: dp-2
     network_uuid: nw-vnet1
     interface_uuid: if-dp2eth0
-    broadcast_mac_address: "02:00:00:bb:00:01"
+    mac_address: "02:00:00:bb:00:01"
 
   - datapath_uuid: dp-2
     network_uuid: nw-vnet2
     interface_uuid: if-dp2eth0
-    broadcast_mac_address: "02:00:00:bb:00:02"
+    mac_address: "02:00:00:bb:00:02"
 
   - datapath_uuid: dp-3
     network_uuid: nw-vnet1
     interface_uuid: if-dp3eth0
-    broadcast_mac_address: "02:00:00:cc:00:01"
+    mac_address: "02:00:00:cc:00:01"
 
   - datapath_uuid: dp-3
     network_uuid: nw-vnet2
     interface_uuid: if-dp3eth0
-    broadcast_mac_address: "02:00:00:cc:00:02"
+    mac_address: "02:00:00:cc:00:02"
 
 filters:
 

--- a/integration_test/dataset/lease_policy.yml
+++ b/integration_test/dataset/lease_policy.yml
@@ -50,17 +50,17 @@ datapath_networks:
   - datapath_uuid: dp-1
     network_uuid: nw-vnet1
     interface_uuid: if-dp1eth0
-    broadcast_mac_address: "02:00:00:aa:00:01"
+    mac_address: "02:00:00:aa:00:01"
 
   - datapath_uuid: dp-2
     network_uuid: nw-vnet1
     interface_uuid: if-dp2eth0
-    broadcast_mac_address: "02:00:00:bb:00:01"
+    mac_address: "02:00:00:bb:00:01"
 
   - datapath_uuid: dp-3
     network_uuid: nw-vnet1
     interface_uuid: if-dp3eth0
-    broadcast_mac_address: "02:00:00:cc:00:01"
+    mac_address: "02:00:00:cc:00:01"
 
 lease_policies:
   - uuid: lp-1

--- a/integration_test/dataset/router_p2v.yml
+++ b/integration_test/dataset/router_p2v.yml
@@ -113,32 +113,32 @@ datapath_networks:
   - datapath_uuid: dp-1
     network_uuid: nw-vnet1
     interface_uuid: if-dp1eth0
-    broadcast_mac_address: "02:00:00:aa:00:01"
+    mac_address: "02:00:00:aa:00:01"
 
   - datapath_uuid: dp-1
     network_uuid: nw-vnet2
     interface_uuid: if-dp1eth0
-    broadcast_mac_address: "02:00:00:aa:00:02"
+    mac_address: "02:00:00:aa:00:02"
 
   - datapath_uuid: dp-2
     network_uuid: nw-vnet1
     interface_uuid: if-dp2eth0
-    broadcast_mac_address: "02:00:00:bb:00:01"
+    mac_address: "02:00:00:bb:00:01"
 
   - datapath_uuid: dp-2
     network_uuid: nw-vnet2
     interface_uuid: if-dp2eth0
-    broadcast_mac_address: "02:00:00:bb:00:02"
+    mac_address: "02:00:00:bb:00:02"
 
   - datapath_uuid: dp-3
     network_uuid: nw-vnet1
     interface_uuid: if-dp3eth0
-    broadcast_mac_address: "02:00:00:cc:00:01"
+    mac_address: "02:00:00:cc:00:01"
 
   - datapath_uuid: dp-3
     network_uuid: nw-vnet2
     interface_uuid: if-dp3eth0
-    broadcast_mac_address: "02:00:00:cc:00:02"
+    mac_address: "02:00:00:cc:00:02"
 
 route_links:
 

--- a/integration_test/dataset/router_v2v.yml
+++ b/integration_test/dataset/router_v2v.yml
@@ -108,32 +108,32 @@ datapath_networks:
   - datapath_uuid: dp-1
     network_uuid: nw-vnet1
     interface_uuid: if-dp1eth0
-    broadcast_mac_address: "02:00:00:aa:00:01"
+    mac_address: "02:00:00:aa:00:01"
 
   - datapath_uuid: dp-1
     network_uuid: nw-vnet2
     interface_uuid: if-dp1eth0
-    broadcast_mac_address: "02:00:00:aa:00:02"
+    mac_address: "02:00:00:aa:00:02"
 
   - datapath_uuid: dp-2
     network_uuid: nw-vnet1
     interface_uuid: if-dp2eth0
-    broadcast_mac_address: "02:00:00:bb:00:01"
+    mac_address: "02:00:00:bb:00:01"
 
   - datapath_uuid: dp-2
     network_uuid: nw-vnet2
     interface_uuid: if-dp2eth0
-    broadcast_mac_address: "02:00:00:bb:00:02"
+    mac_address: "02:00:00:bb:00:02"
 
   - datapath_uuid: dp-3
     network_uuid: nw-vnet1
     interface_uuid: if-dp3eth0
-    broadcast_mac_address: "02:00:00:cc:00:01"
+    mac_address: "02:00:00:cc:00:01"
 
   - datapath_uuid: dp-3
     network_uuid: nw-vnet2
     interface_uuid: if-dp3eth0
-    broadcast_mac_address: "02:00:00:cc:00:02"
+    mac_address: "02:00:00:cc:00:02"
 
 route_links:
 

--- a/integration_test/dataset/secg.yml
+++ b/integration_test/dataset/secg.yml
@@ -84,32 +84,32 @@ datapath_networks:
   - datapath_uuid: dp-1
     network_uuid: nw-vnet1
     interface_uuid: if-dp1eth0
-    broadcast_mac_address: "02:00:00:aa:00:01"
+    mac_address: "02:00:00:aa:00:01"
 
   - datapath_uuid: dp-1
     network_uuid: nw-vnet2
     interface_uuid: if-dp1eth0
-    broadcast_mac_address: "02:00:00:aa:00:02"
+    mac_address: "02:00:00:aa:00:02"
 
   - datapath_uuid: dp-2
     network_uuid: nw-vnet1
     interface_uuid: if-dp2eth0
-    broadcast_mac_address: "02:00:00:bb:00:01"
+    mac_address: "02:00:00:bb:00:01"
 
   - datapath_uuid: dp-2
     network_uuid: nw-vnet2
     interface_uuid: if-dp2eth0
-    broadcast_mac_address: "02:00:00:bb:00:02"
+    mac_address: "02:00:00:bb:00:02"
 
   - datapath_uuid: dp-3
     network_uuid: nw-vnet1
     interface_uuid: if-dp3eth0
-    broadcast_mac_address: "02:00:00:cc:00:01"
+    mac_address: "02:00:00:cc:00:01"
 
   - datapath_uuid: dp-3
     network_uuid: nw-vnet2
     interface_uuid: if-dp3eth0
-    broadcast_mac_address: "02:00:00:cc:00:02"
+    mac_address: "02:00:00:cc:00:02"
 
 security_groups:
 

--- a/integration_test/dataset/secg_reference.yml
+++ b/integration_test/dataset/secg_reference.yml
@@ -67,17 +67,17 @@ datapath_networks:
   - datapath_uuid: dp-1
     network_uuid: nw-vnet1
     interface_uuid: if-dp1eth0
-    broadcast_mac_address: "02:00:00:aa:00:01"
+    mac_address: "02:00:00:aa:00:01"
 
   - datapath_uuid: dp-2
     network_uuid: nw-vnet1
     interface_uuid: if-dp2eth0
-    broadcast_mac_address: "02:00:00:bb:00:01"
+    mac_address: "02:00:00:bb:00:01"
 
   - datapath_uuid: dp-3
     network_uuid: nw-vnet1
     interface_uuid: if-dp3eth0
-    broadcast_mac_address: "02:00:00:cc:00:01"
+    mac_address: "02:00:00:cc:00:01"
 
 security_groups:
 

--- a/integration_test/dataset/service.yml
+++ b/integration_test/dataset/service.yml
@@ -99,32 +99,32 @@ datapath_networks:
   - datapath_uuid: dp-1
     network_uuid: nw-vnet1
     interface_uuid: if-dp1eth0
-    broadcast_mac_address: "02:00:00:aa:00:01"
+    mac_address: "02:00:00:aa:00:01"
 
   - datapath_uuid: dp-1
     network_uuid: nw-vnet2
     interface_uuid: if-dp1eth0
-    broadcast_mac_address: "02:00:00:aa:00:02"
+    mac_address: "02:00:00:aa:00:02"
 
   - datapath_uuid: dp-2
     network_uuid: nw-vnet1
     interface_uuid: if-dp2eth0
-    broadcast_mac_address: "02:00:00:bb:00:01"
+    mac_address: "02:00:00:bb:00:01"
 
   - datapath_uuid: dp-2
     network_uuid: nw-vnet2
     interface_uuid: if-dp2eth0
-    broadcast_mac_address: "02:00:00:bb:00:02"
+    mac_address: "02:00:00:bb:00:02"
 
   - datapath_uuid: dp-3
     network_uuid: nw-vnet1
     interface_uuid: if-dp3eth0
-    broadcast_mac_address: "02:00:00:cc:00:01"
+    mac_address: "02:00:00:cc:00:01"
 
   - datapath_uuid: dp-3
     network_uuid: nw-vnet2
     interface_uuid: if-dp3eth0
-    broadcast_mac_address: "02:00:00:cc:00:02"
+    mac_address: "02:00:00:cc:00:02"
 
 dns_services:
 

--- a/integration_test/dataset/simple.yml
+++ b/integration_test/dataset/simple.yml
@@ -79,29 +79,29 @@ datapath_networks:
   - datapath_uuid: dp-1
     network_uuid: nw-vnet1
     interface_uuid: if-dp1eth0
-    broadcast_mac_address: "02:00:00:aa:00:01"
+    mac_address: "02:00:00:aa:00:01"
 
   - datapath_uuid: dp-1
     network_uuid: nw-vnet2
     interface_uuid: if-dp1eth0
-    broadcast_mac_address: "02:00:00:aa:00:02"
+    mac_address: "02:00:00:aa:00:02"
 
   - datapath_uuid: dp-2
     network_uuid: nw-vnet1
     interface_uuid: if-dp2eth0
-    broadcast_mac_address: "02:00:00:bb:00:01"
+    mac_address: "02:00:00:bb:00:01"
 
   - datapath_uuid: dp-2
     network_uuid: nw-vnet2
     interface_uuid: if-dp2eth0
-    broadcast_mac_address: "02:00:00:bb:00:02"
+    mac_address: "02:00:00:bb:00:02"
 
   - datapath_uuid: dp-3
     network_uuid: nw-vnet1
     interface_uuid: if-dp3eth0
-    broadcast_mac_address: "02:00:00:cc:00:01"
+    mac_address: "02:00:00:cc:00:01"
 
   - datapath_uuid: dp-3
     network_uuid: nw-vnet2
     interface_uuid: if-dp3eth0
-    broadcast_mac_address: "02:00:00:cc:00:02"
+    mac_address: "02:00:00:cc:00:02"

--- a/integration_test/lib/vnspec/spec/event_spec.rb
+++ b/integration_test/lib/vnspec/spec/event_spec.rb
@@ -152,19 +152,19 @@ describe "event" do
         datapath.add_datapath_network(
           "nw-public1",
           interface_uuid: "if-dp1eth0",
-          broadcast_mac_address: "02:00:00:aa:01:01"
+          mac_address: "02:00:00:aa:01:01"
         )
 
         datapath.add_datapath_network(
           "nw-vnet1",
           interface_uuid: "if-dp1eth0",
-          broadcast_mac_address: "02:00:00:aa:00:01"
+          mac_address: "02:00:00:aa:00:01"
         )
 
         datapath.add_datapath_network(
           "nw-vnet2",
           interface_uuid: "if-dp1eth0",
-          broadcast_mac_address: "02:00:00:aa:00:02"
+          mac_address: "02:00:00:aa:00:02"
         )
 
         sleep(1)

--- a/vnet/lib/vnet/endpoints/1.0/datapaths.rb
+++ b/vnet/lib/vnet/endpoints/1.0/datapaths.rb
@@ -83,7 +83,7 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/datapaths' do
     options = {
       datapath_id: check_syntax_and_pop_uuid(M::Datapath).id,
       interface_id: check_syntax_and_pop_uuid(M::Interface, 'interface_uuid').id,
-      route_link: route_link.id,
+      route_link_id: route_link.id,
       mac_address: params["mac_address"]
     }
 

--- a/vnet/lib/vnet/endpoints/1.0/datapaths.rb
+++ b/vnet/lib/vnet/endpoints/1.0/datapaths.rb
@@ -41,24 +41,16 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/datapaths' do
   end
 
   param_uuid M::Interface, :interface_uuid, required: true
-
-  # 'broadcast_mac_address' is deprecated and should be phased out.
-  param :mac_address, :String, transform: PARSE_MAC
-  param :broadcast_mac_address, :String, transform: PARSE_MAC
+  param :mac_address, :String, required: true, transform: PARSE_MAC
   post '/:uuid/networks/:network_uuid' do
-    datapath = check_syntax_and_pop_uuid(M::Datapath)
-    interface = check_syntax_and_pop_uuid(M::Interface, 'interface_uuid')
-    network = check_syntax_and_pop_uuid(M::Network, 'network_uuid')
+    options = {
+      datapath_id: check_syntax_and_pop_uuid(M::Datapath).id,
+      interface_id: check_syntax_and_pop_uuid(M::Interface, 'interface_uuid').id,
+      network_id: check_syntax_and_pop_uuid(M::Network, 'network_uuid').id,
+      mac_address: params["mac_address"]
+    }
 
-    mac_address = params["mac_address"] || params["broadcast_mac_address"]
-
-    M::DatapathNetwork.create({ :datapath_id => datapath.id,
-                                :interface_id => interface.id,
-                                :network_id => network.id,
-                                :mac_address => mac_address
-                              })
-
-    respond_with(R::Network.generate(network))
+    respond_with(R::Network.generate(M::DatapathNetwork.create(options)))
   end
 
   get '/:uuid/networks' do
@@ -66,10 +58,14 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/datapaths' do
   end
 
   delete '/:uuid/networks/:network_uuid' do
-    datapath = check_syntax_and_pop_uuid(M::Datapath)
     network = check_syntax_and_pop_uuid(M::Network, 'network_uuid')
 
-    M::DatapathNetwork.destroy(datapath_id: datapath.id, generic_id: network.id)
+    options = {
+      datapath_id: check_syntax_and_pop_uuid(M::Datapath).id,
+      generic_id: network.id,
+    }
+
+    M::DatapathNetwork.destroy(options)
 
     respond_with([network.uuid])
   end
@@ -77,17 +73,14 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/datapaths' do
   param_uuid M::Interface, :interface_uuid, required: true
   param :mac_address, :String, required: true, transform: PARSE_MAC
   post '/:uuid/route_links/:route_link_uuid' do
-    datapath = check_syntax_and_pop_uuid(M::Datapath)
-    interface = check_syntax_and_pop_uuid(M::Interface, 'interface_uuid')
-    route_link = check_syntax_and_pop_uuid(M::RouteLink, 'route_link_uuid')
+    options = {
+      datapath_id: check_syntax_and_pop_uuid(M::Datapath).id,
+      interface_id: check_syntax_and_pop_uuid(M::Interface, 'interface_uuid').id,
+      route_link: check_syntax_and_pop_uuid(M::RouteLink, 'route_link_uuid').id,
+      mac_address: params["mac_address"]
+    }
 
-    M::DatapathRouteLink.create({ :datapath_id => datapath.id,
-                                  :interface_id => interface.id,
-                                  :route_link_id => route_link.id,
-                                  :mac_address => params["mac_address"],
-                                })
-
-    respond_with(R::RouteLink.generate(route_link))
+    respond_with(R::RouteLink.generate(M::DatapathRouteLink.create(options)))
   end
 
   get '/:uuid/route_links' do
@@ -95,10 +88,14 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/datapaths' do
   end
 
   delete '/:uuid/route_links/:route_link_uuid' do
-    datapath = check_syntax_and_pop_uuid(M::Datapath)
     route_link = check_syntax_and_pop_uuid(M::RouteLink, 'route_link_uuid')
 
-    M::DatapathRouteLink.destroy(datapath_id: datapath.id, generic_id: route_link.id)
+    options = {
+      datapath_id: check_syntax_and_pop_uuid(M::Datapath).id,
+      generic_id: route_link.id
+    }
+
+    M::DatapathRouteLink.destroy(options)
 
     respond_with([route_link.uuid])
   end

--- a/vnet/lib/vnet/endpoints/1.0/datapaths.rb
+++ b/vnet/lib/vnet/endpoints/1.0/datapaths.rb
@@ -43,14 +43,19 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/datapaths' do
   param_uuid M::Interface, :interface_uuid, required: true
   param :mac_address, :String, required: true, transform: PARSE_MAC
   post '/:uuid/networks/:network_uuid' do
+    network = check_syntax_and_pop_uuid(M::Network, 'network_uuid')
+
     options = {
       datapath_id: check_syntax_and_pop_uuid(M::Datapath).id,
       interface_id: check_syntax_and_pop_uuid(M::Interface, 'interface_uuid').id,
-      network_id: check_syntax_and_pop_uuid(M::Network, 'network_uuid').id,
+      network_id: network.id,
       mac_address: params["mac_address"]
     }
 
-    respond_with(R::Network.generate(M::DatapathNetwork.create(options)))
+    M::DatapathNetwork.create(options)
+
+    # TODO: Change return type.
+    respond_with(R::Network.generate(network))
   end
 
   get '/:uuid/networks' do
@@ -73,14 +78,19 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/datapaths' do
   param_uuid M::Interface, :interface_uuid, required: true
   param :mac_address, :String, required: true, transform: PARSE_MAC
   post '/:uuid/route_links/:route_link_uuid' do
+    route_link = check_syntax_and_pop_uuid(M::RouteLink, 'route_link_uuid')
+
     options = {
       datapath_id: check_syntax_and_pop_uuid(M::Datapath).id,
       interface_id: check_syntax_and_pop_uuid(M::Interface, 'interface_uuid').id,
-      route_link: check_syntax_and_pop_uuid(M::RouteLink, 'route_link_uuid').id,
+      route_link: route_link.id,
       mac_address: params["mac_address"]
     }
 
-    respond_with(R::RouteLink.generate(M::DatapathRouteLink.create(options)))
+    M::DatapathRouteLink.create(options)
+
+    # TODO: Change return type.
+    respond_with(R::RouteLink.generate(route_link))
   end
 
   get '/:uuid/route_links' do
@@ -97,6 +107,7 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/datapaths' do
 
     M::DatapathRouteLink.destroy(options)
 
+    # TODO: Change return type.
     respond_with([route_link.uuid])
   end
 

--- a/vnet/spec/vnet/core/filters2_spec.rb
+++ b/vnet/spec/vnet/core/filters2_spec.rb
@@ -22,6 +22,7 @@ describe Vnet::Core::Filter2Manager do
 
   before(:each) do
     filter2_manager.publish(Vnet::Event::FILTER_ACTIVATE_INTERFACE, id: :interface, interface_id: 1)
+    sleep(0.01)
     filter2_manager.publish(Vnet::Event::FILTER_CREATED_ITEM, filter.to_hash)
     expect(filter2_manager.wait_for_loaded({id: filter.id}, 3)).not_to be_nil
   end
@@ -121,6 +122,7 @@ describe Vnet::Core::Filter2Manager do
                               filter_static.to_hash.merge(id: filter.id,
                                                           static_id: filter_static.id))
     end
+
     context "when a static rule has been added" do
       let(:filter_static) { Fabricate(:static_pass, protocol: "tcp") }
       it "removes a static rule" do

--- a/vnet/spec/vnet/core/filters2_spec.rb
+++ b/vnet/spec/vnet/core/filters2_spec.rb
@@ -20,7 +20,6 @@ describe Vnet::Core::Filter2Manager do
                            interface_id: 1,
                            mode: "static") }
 
-  # TODO: Sleep timers here create random fails based on load. Use wait_for_loaded.
   before(:each) do
     filter2_manager.publish(Vnet::Event::FILTER_ACTIVATE_INTERFACE, id: :interface, interface_id: 1)
     filter2_manager.publish(Vnet::Event::FILTER_CREATED_ITEM, filter.to_hash)

--- a/vnet/spec/vnet/core/filters2_spec.rb
+++ b/vnet/spec/vnet/core/filters2_spec.rb
@@ -23,7 +23,6 @@ describe Vnet::Core::Filter2Manager do
   # TODO: Sleep timers here create random fails based on load. Use wait_for_loaded.
   before(:each) do
     filter2_manager.publish(Vnet::Event::FILTER_ACTIVATE_INTERFACE, id: :interface, interface_id: 1)
-    sleep(0.2)
     filter2_manager.publish(Vnet::Event::FILTER_CREATED_ITEM, filter.to_hash)
     expect(filter2_manager.wait_for_loaded({id: filter.id}, 3)).not_to be_nil
   end

--- a/vnet/spec/vnet/core/filters2_spec.rb
+++ b/vnet/spec/vnet/core/filters2_spec.rb
@@ -20,11 +20,12 @@ describe Vnet::Core::Filter2Manager do
                            interface_id: 1,
                            mode: "static") }
 
+  # TODO: Sleep timers here create random fails based on load. Use wait_for_loaded.
   before(:each) do
     filter2_manager.publish(Vnet::Event::FILTER_ACTIVATE_INTERFACE, id: :interface, interface_id: 1)
     sleep(0.2)
     filter2_manager.publish(Vnet::Event::FILTER_CREATED_ITEM, filter.to_hash)
-    sleep(0.2)
+    expect(filter2_manager.wait_for_loaded({id: filter.id}, 3)).not_to be_nil
   end
 
   shared_examples_for "filter_methods" do |operation, passthrough, event = nil|


### PR DESCRIPTION
Fixes #383.

Due to using both broadcat_mac_address and mac_address, the dp_nw API accepted nil input. For consistency with dp_rl and testing this was set to require input.

Next update will change the db to not allow nil mac_address and allow nil in the API. This will make it possible to use the default mac range group again.