### PR TITLE
Feature do_initialize

### DIFF
--- a/vnet/lib/vnet/core/interface_port_manager.rb
+++ b/vnet/lib/vnet/core/interface_port_manager.rb
@@ -21,11 +21,6 @@ module Vnet::Core
     subscribe_event INTERFACE_PORT_ACTIVATE, :activate_port
     subscribe_event INTERFACE_PORT_DEACTIVATE, :deactivate_port
 
-    # When event handling is set to drop-all, this does nothing.
-    def load_internal_interfaces
-      internal_load_where(mode: 'internal', allowed_datapath: true)
-    end
-
     def load_simulated_on_network_id(network_id)
       # TODO: Add list of active network id's for which we should have
       # simulated interfaces loaded.
@@ -93,6 +88,11 @@ module Vnet::Core
       end
 
       filter
+    end
+
+    def do_initialize
+      # When event handling is set to drop-all, this does nothing.
+      internal_load_where(mode: 'internal', allowed_datapath: true)
     end
 
     # We only initialize interface ports that are allowed on this

--- a/vnet/lib/vnet/core/port_manager.rb
+++ b/vnet/lib/vnet/core/port_manager.rb
@@ -13,16 +13,6 @@ module Vnet::Core
     subscribe_event PORT_ATTACH_INTERFACE, :attach_interface
     subscribe_event PORT_DETACH_INTERFACE, :detach_interface
 
-    def initialize_ports
-      return if @datapath_info.nil?
-
-      # Iterate through a copy of the items else 'insert/delete' may
-      # cause issues.
-      @items.keys.each { |id|
-        publish(PORT_INITIALIZED, id: id)
-      }
-    end
-
     def insert(port_desc)
       if @items[port_desc.port_no]
         info log_format('port already added', "port_name:#{port_desc.name} port_number:#{port_desc.port_no}")
@@ -92,6 +82,14 @@ module Vnet::Core
     #
     # Event handlers.
     #
+
+    def do_initialize
+      # Iterate through a copy of the items else 'insert/delete' may
+      # cause issues.
+      @items.keys.each { |id|
+        publish(PORT_INITIALIZED, id: id)
+      }
+    end
 
     def install_item(params)
       port = @items[params[:id]] || return

--- a/vnet/lib/vnet/manager.rb
+++ b/vnet/lib/vnet/manager.rb
@@ -45,6 +45,8 @@ module Vnet
     # requires the use of local events.
 
     def initialize(info, options = {})
+      @state = :uninitialized
+
       @items = {}
       @messages = {}
 
@@ -99,6 +101,10 @@ module Vnet
     # Polling methods:
     #
 
+    def wait_for_initialized(max_wait = 10.0)
+      internal_wait_for_initialized(max_wait)
+    end
+
     def wait_for_loaded(params, max_wait = 10.0, try_load = false)
       item_to_hash(internal_wait_for_loaded(params, max_wait, try_load))
     end
@@ -137,6 +143,21 @@ module Vnet
       # We need to update remote interfaces in case they are now in
       # our datapath.
       initialized_datapath_info
+      nil
+    end
+
+    def start_initialize
+      if @state != :uninitialized
+        raise("Manager.start_initialized must be called on an uninitialized manager.")
+      end
+
+      do_initialize
+      
+      @state = :initialized
+
+      # TODO: Catch errors and return nil when do_initialize fails.
+      resume_event_tasks(:initialized, true)
+      nil
     end
 
     #
@@ -177,6 +198,9 @@ module Vnet
     end
 
     def cleared_datapath_info
+    end
+
+    def do_initialize
     end
 
     #
@@ -531,6 +555,17 @@ module Vnet
     #
     # Internal polling methods:
     #
+
+    def internal_wait_for_initialized(max_wait)
+      if @state == :initialized
+        return
+      end
+
+      # TODO: Check for invalid state, cleaned up, etc.
+      create_event_task(:initialized, max_wait) { |result|
+        true
+      }
+    end
 
     # TODO: Wait_for_loaded needs to work correctly when create is
     # called and the manager doesn't know the item is wanted.

--- a/vnet/lib/vnet/openflow/datapath.rb
+++ b/vnet/lib/vnet/openflow/datapath.rb
@@ -166,34 +166,22 @@ module Vnet::Openflow
       }
     end
 
+    # TODO: Call this from somewhere.
     def initialize_bootstrap_managers
-      @dp_info.bootstrap_managers.each { |manager|
-        manager.set_datapath_info(@datapath_info)
-      }
-      @dp_info.bootstrap_managers.each { |manager|
-        manager.async.start_initialize
-      }
-      @dp_info.bootstrap_managers.each { |manager|
-        manager.wait_for_initialized(nil)
-      }
-      @dp_info.bootstrap_managers.each { |manager|
-        manager.event_handler_active
-      }
+      managers = @dp_info.bootstrap_managers
+      managers.each { |manager| manager.event_handler_queue_only }
+      managers.each { |manager| manager.async.start_initialize }
+      managers.each { |manager| manager.wait_for_initialized(nil) }
+      managers.each { |manager| manager.event_handler_active }
     end
 
     def initialize_managers
-      @dp_info.managers.each { |manager|
-        manager.set_datapath_info(@datapath_info)
-      }
-      @dp_info.managers.each { |manager|
-        manager.async.start_initialize
-      }
-      @dp_info.managers.each { |manager|
-        manager.wait_for_initialized(nil)
-      }
-      @dp_info.managers.each { |manager|
-        manager.event_handler_active
-      }
+      managers = @dp_info.managers
+      managers.each { |manager| manager.set_datapath_info(@datapath_info) }
+      managers.each { |manager| manager.event_handler_queue_only }
+      managers.each { |manager| manager.async.start_initialize }
+      managers.each { |manager| manager.wait_for_initialized(nil) }
+      managers.each { |manager| manager.event_handler_active }
     end
 
   end

--- a/vnet/lib/vnet/openflow/datapath.rb
+++ b/vnet/lib/vnet/openflow/datapath.rb
@@ -166,17 +166,18 @@ module Vnet::Openflow
       }
     end
 
-    # TODO: Add a way to block events from being processed by managers
-    # until everything has been initialized.
     def initialize_bootstrap_managers
       @dp_info.bootstrap_managers.each { |manager|
         manager.set_datapath_info(@datapath_info)
       }
-      @dp_info.managers.each { |manager|
+      @dp_info.bootstrap_managers.each { |manager|
         manager.async.start_initialize
       }
-      @dp_info.managers.each { |manager|
+      @dp_info.bootstrap_managers.each { |manager|
         manager.wait_for_initialized(nil)
+      }
+      @dp_info.bootstrap_managers.each { |manager|
+        manager.event_handler_active
       }
     end
 
@@ -190,13 +191,6 @@ module Vnet::Openflow
       @dp_info.managers.each { |manager|
         manager.wait_for_initialized(nil)
       }
-
-      # Until we have datapath_info loaded none of the ports can be
-      # initialized.
-      @dp_info.interface_port_manager.load_internal_interfaces
-      @dp_info.port_manager.initialize_ports
-
-      # All managers should be initialized, allow events to execute.
       @dp_info.managers.each { |manager|
         manager.event_handler_active
       }

--- a/vnet/lib/vnet/openflow/datapath.rb
+++ b/vnet/lib/vnet/openflow/datapath.rb
@@ -172,16 +172,24 @@ module Vnet::Openflow
       @dp_info.bootstrap_managers.each { |manager|
         manager.set_datapath_info(@datapath_info)
       }
+      @dp_info.managers.each { |manager|
+        manager.async.start_initialize
+      }
+      @dp_info.managers.each { |manager|
+        manager.wait_for_initialized(nil)
+      }
     end
 
     def initialize_managers
       @dp_info.managers.each { |manager|
         manager.set_datapath_info(@datapath_info)
       }
-
-      # TODO: Add a default do_initialize method to manager and
-      # parallelize them.
-      @dp_info.active_port_manager.do_initialize
+      @dp_info.managers.each { |manager|
+        manager.async.start_initialize
+      }
+      @dp_info.managers.each { |manager|
+        manager.wait_for_initialized(nil)
+      }
 
       # Until we have datapath_info loaded none of the ports can be
       # initialized.


### PR DESCRIPTION
#388

Adds proper concurrent initialization of managers with barriers that allows them to safely initialize with events being queue-only, then active as all managers have finished initializing.