### PR TITLE
Fix dp nwrl not null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * `Changed` Added a default value of `false` to all `is_deleted` flags in the database. Now OpenVNet can be used with MySQL's STRICT mode.
 
+* `Changed` The `mac_address` parameter in the WebAPI's `datapath_networks` and `datapath_route_links` endpoints are no longer required. OpenVNet will now generate them if not provided.
+
 * `Fixed` An issue where vna could retrieve network resources from vnmgr while their related resources were not fully loaded yet.
 
 ## [0.8] - 2015-09-04

--- a/vnet/db/migrations/0008_dp_nwrl_not_null.rb
+++ b/vnet/db/migrations/0008_dp_nwrl_not_null.rb
@@ -4,24 +4,24 @@ Sequel.migration do
   up do
     alter_table(:datapath_networks) do
       set_column_not_null :mac_address_id
-      set_column_not_null :ip_lease_id
+      #set_column_not_null :ip_lease_id
     end
 
     alter_table(:datapath_route_links) do
       set_column_not_null :mac_address_id
-      set_column_not_null :ip_lease_id
+      #set_column_not_null :ip_lease_id
     end
   end
 
   down do
     alter_table(:datapath_networks) do
       set_column_allow_null :mac_address_id
-      set_column_allow_null :ip_lease_id
+      #set_column_allow_null :ip_lease_id
     end
 
     alter_table(:datapath_route_links) do
       set_column_allow_null :mac_address_id
-      set_column_allow_null :ip_lease_id
+      #set_column_allow_null :ip_lease_id
     end
   end
 end

--- a/vnet/db/migrations/0008_dp_nwrl_not_null.rb
+++ b/vnet/db/migrations/0008_dp_nwrl_not_null.rb
@@ -4,24 +4,20 @@ Sequel.migration do
   up do
     alter_table(:datapath_networks) do
       set_column_not_null :mac_address_id
-      #set_column_not_null :ip_lease_id
     end
 
     alter_table(:datapath_route_links) do
       set_column_not_null :mac_address_id
-      #set_column_not_null :ip_lease_id
     end
   end
 
   down do
     alter_table(:datapath_networks) do
       set_column_allow_null :mac_address_id
-      #set_column_allow_null :ip_lease_id
     end
 
     alter_table(:datapath_route_links) do
       set_column_allow_null :mac_address_id
-      #set_column_allow_null :ip_lease_id
     end
   end
 end

--- a/vnet/db/migrations/0008_dp_nwrl_not_null.rb
+++ b/vnet/db/migrations/0008_dp_nwrl_not_null.rb
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+Sequel.migration do
+  up do
+    alter_table(:datapath_networks) do
+      set_column_not_null :mac_address_id
+      set_column_not_null :ip_lease_id
+    end
+
+    alter_table(:datapath_route_links) do
+      set_column_not_null :mac_address_id
+      set_column_not_null :ip_lease_id
+    end
+  end
+
+  down do
+    alter_table(:datapath_networks) do
+      set_column_allow_null :mac_address_id
+      set_column_allow_null :ip_lease_id
+    end
+
+    alter_table(:datapath_route_links) do
+      set_column_allow_null :mac_address_id
+      set_column_allow_null :ip_lease_id
+    end
+  end
+end

--- a/vnet/lib/vnet/endpoints/1.0/datapaths.rb
+++ b/vnet/lib/vnet/endpoints/1.0/datapaths.rb
@@ -41,7 +41,7 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/datapaths' do
   end
 
   param_uuid M::Interface, :interface_uuid, required: true
-  param :mac_address, :String, required: true, transform: PARSE_MAC
+  param :mac_address, :String, required: false, transform: PARSE_MAC
   post '/:uuid/networks/:network_uuid' do
     network = check_syntax_and_pop_uuid(M::Network, 'network_uuid')
 
@@ -52,10 +52,8 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/datapaths' do
       mac_address: params["mac_address"]
     }
 
-    M::DatapathNetwork.create(options)
-
-    # TODO: Change return type.
-    respond_with(R::Network.generate(network))
+    object = M::DatapathNetwork.create(options)
+    respond_with(R::DatapathNetwork.generate(object))
   end
 
   get '/:uuid/networks' do
@@ -76,7 +74,7 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/datapaths' do
   end
 
   param_uuid M::Interface, :interface_uuid, required: true
-  param :mac_address, :String, required: true, transform: PARSE_MAC
+  param :mac_address, :String, required: false, transform: PARSE_MAC
   post '/:uuid/route_links/:route_link_uuid' do
     route_link = check_syntax_and_pop_uuid(M::RouteLink, 'route_link_uuid')
 
@@ -87,10 +85,8 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/datapaths' do
       mac_address: params["mac_address"]
     }
 
-    M::DatapathRouteLink.create(options)
-
-    # TODO: Change return type.
-    respond_with(R::RouteLink.generate(route_link))
+    object = M::DatapathRouteLink.create(options)
+    respond_with(R::DatapathRouteLink.generate(object))
   end
 
   get '/:uuid/route_links' do

--- a/vnet/lib/vnet/endpoints/1.0/responses/datapath_network.rb
+++ b/vnet/lib/vnet/endpoints/1.0/responses/datapath_network.rb
@@ -3,12 +3,8 @@
 module Vnet::Endpoints::V10::Responses
   class DatapathNetwork < Vnet::Endpoints::CollectionResponseGenerator
     def self.generate(object)
-      argument_type_check(object,Vnet::ModelWrappers::DatapathNetwork)
-      network_uuid = Vnet::ModelWrappers::Network.find(:id => object.network_id).uuid
-      {
-        :network_uuid => network_uuid,
-        :mac_address => object.mac_address
-      }
+      argument_type_check(object, Vnet::ModelWrappers::DatapathNetwork)
+      object.to_hash
     end
   end
 

--- a/vnet/lib/vnet/endpoints/1.0/responses/datapath_route_link.rb
+++ b/vnet/lib/vnet/endpoints/1.0/responses/datapath_route_link.rb
@@ -4,13 +4,7 @@ module Vnet::Endpoints::V10::Responses
   class DatapathRouteLink < Vnet::Endpoints::CollectionResponseGenerator
     def self.generate(object)
       argument_type_check(object,Vnet::ModelWrappers::DatapathRouteLink)
-      relation = Vnet::ModelWrappers::RouteLink.find(:id => object.route_link_id)
-      route_link_uuid = relation.uuid
-      {
-        :route_link_uuid => route_link_uuid,
-        :mac_address => relation.mac_address,
-        :is_connected => relation.is_connected
-      }
+      object.to_hash
     end
   end
 

--- a/vnet/spec/fabricators/interface_fabricator.rb
+++ b/vnet/spec/fabricators/interface_fabricator.rb
@@ -53,6 +53,27 @@ Fabricator(:filter_interface, class_name: Vnet::Models::Interface) do
 
 end
 
+Fabricator(:interface_w_ip_lease, class_name: Vnet::Models::Interface) do
+  id { sequence(:interface_ids, 1) }
+
+  ip_leases do |attrs|
+    [
+     Fabricate(:ip_lease_any) do
+       interface_id { attrs[:id] }
+       mac_lease { Fabricate(:mac_lease_any,
+                             mac_address: sequence(:mac_address),
+                             interface_id: attrs[:id]
+                             )}
+       network_id { Fabricate(:network).id }
+       ip_address_id { |attrs|
+         Fabricate(:ip_address_no_nw, network_id: attrs[:network_id]).id
+       }
+       # ipv4_address { Fabricate(:ip_address) }
+     end
+    ]
+  end
+end
+
 Fabricator(:interface_dp1eth0, class_name: Vnet::Models::Interface) do
   uuid 'if-dp1eth0'
   display_name "test-dp1eth0"

--- a/vnet/spec/vnet/endpoints/1.0/datapaths_spec.rb
+++ b/vnet/spec/vnet/endpoints/1.0/datapaths_spec.rb
@@ -48,7 +48,7 @@ describe "/datapaths" do
     let!(:base_object) { Fabricate(fabricator) }
     let(:relation_fabricator) { :network }
 
-    let!(:interface) { Fabricate(:interface) { uuid "if-test" } }
+    let!(:interface) { Fabricate(:interface_w_ip_lease) { uuid "if-test" } }
 
     include_examples "many_to_many_relation", "networks", {
       :mac_address => "02:00:00:cc:00:02",
@@ -60,7 +60,7 @@ describe "/datapaths" do
     let!(:base_object) { Fabricate(fabricator) }
     let(:relation_fabricator) { :route_link }
 
-    let!(:interface) { Fabricate(:interface) { uuid "if-test" } }
+    let!(:interface) { Fabricate(:interface_w_ip_lease) { uuid "if-test" } }
 
     include_examples "many_to_many_relation", "route_links", {
       :mac_address => "02:00:00:cc:00:02",


### PR DESCRIPTION
Allows passing no mac_address to dp_nw/rl and requires dp_nw/rl mac_address_id to be valid in the db.