### PR TITLE
Fix ci network_service mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * `Changed` Optimized manager initialization code so no events can be processed before the targeted managers are properly initialized.
 
+* `Deprecated` The `type` parameter in the WebAPI's network_services endpoint. Use `mode` instead.
+
 * `Changed` Added a default value of `false` to all `is_deleted` flags in the database. Now OpenVNet can be used with MySQL's STRICT mode.
 
 * `Changed` The `mac_address` parameter in the WebAPI's `datapath_networks` and `datapath_route_links` endpoints are no longer required. OpenVNet will now generate them if not provided.

--- a/client/vnctl/lib/vnctl/cli/network_service.rb
+++ b/client/vnctl/lib/vnctl/cli/network_service.rb
@@ -16,7 +16,8 @@ module Vnctl::Cli
 
     add_modify_shared_options
     option_uuid
-    option :type, :type => :string, :desc => "The type of this service."
+    option :type, :type => :string, :desc => "Deprecated. Use mode instead."
+    option :mode, :type => :string, :desc => "The mode of this service."
     define_add
 
     add_modify_shared_options

--- a/client/vnctl/lib/vnctl/cli/network_service.rb
+++ b/client/vnctl/lib/vnctl/cli/network_service.rb
@@ -12,7 +12,8 @@ module Vnctl::Cli
       option :outgoing_port, :type => :numeric, :desc => "The outgoing port for this network service."
     }
 
-    set_required_options [:type]
+    # TODO: Remove 'type' completely and make 'mode' required.
+    # set_required_options [:mode]
 
     add_modify_shared_options
     option_uuid

--- a/integration_test/dataset/base.yml
+++ b/integration_test/dataset/base.yml
@@ -73,11 +73,11 @@ network_services:
 
   - uuid: ns-dhcppub1
     interface_uuid: if-dhcppub1
-    type: dhcp
+    mode: dhcp
 
   - uuid: ns-dhcppub2
     interface_uuid: if-dhcppub2
-    type: dhcp
+    mode: dhcp
 
 datapath_networks:
 

--- a/integration_test/dataset/edge.yml
+++ b/integration_test/dataset/edge.yml
@@ -90,11 +90,11 @@ network_services:
 
   - uuid: ns-dhcp1
     interface_uuid: if-dhcp1
-    type: dhcp
+    mode: dhcp
 
   - uuid: ns-dhcp2
     interface_uuid: if-dhcp2
-    type: dhcp
+    mode: dhcp
 
 datapath_networks:
 

--- a/integration_test/dataset/edge_esxi.yml
+++ b/integration_test/dataset/edge_esxi.yml
@@ -90,11 +90,11 @@ network_services:
 
   - uuid: ns-dhcp1
     interface_uuid: if-dhcp1
-    type: dhcp
+    mode: dhcp
 
   - uuid: ns-dhcp2
     interface_uuid: if-dhcp2
-    type: dhcp
+    mode: dhcp
 
 datapath_networks:
 

--- a/integration_test/dataset/event.yml
+++ b/integration_test/dataset/event.yml
@@ -82,11 +82,11 @@ network_services:
 
   - uuid: ns-dhcp1
     interface_uuid: if-dhcp1
-    type: dhcp
+    mode: dhcp
 
   - uuid: ns-dhcp2
     interface_uuid: if-dhcp2
-    type: dhcp
+    mode: dhcp
 
 datapath_networks:
 

--- a/integration_test/dataset/filter.yml
+++ b/integration_test/dataset/filter.yml
@@ -72,11 +72,11 @@ network_services:
 
   - uuid: ns-dhcp1
     interface_uuid: if-dhcp1
-    type: dhcp
+    mode: dhcp
 
   - uuid: ns-dhcp2
     interface_uuid: if-dhcp2
-    type: dhcp
+    mode: dhcp
 
 datapath_networks:
 

--- a/integration_test/dataset/lease_policy.yml
+++ b/integration_test/dataset/lease_policy.yml
@@ -43,7 +43,7 @@ network_services:
 
   - uuid: ns-dhcp1
     interface_uuid: if-dhcp1
-    type: dhcp
+    mode: dhcp
 
 datapath_networks:
 

--- a/integration_test/dataset/router_p2v.yml
+++ b/integration_test/dataset/router_p2v.yml
@@ -90,11 +90,11 @@ network_services:
 
   - uuid: ns-dhcp1
     interface_uuid: if-dhcp1
-    type: dhcp
+    mode: dhcp
 
   - uuid: ns-dhcp2
     interface_uuid: if-dhcp2
-    type: dhcp
+    mode: dhcp
 
 datapath_networks:
 

--- a/integration_test/dataset/router_v2v.yml
+++ b/integration_test/dataset/router_v2v.yml
@@ -89,11 +89,11 @@ network_services:
 
   - uuid: ns-dhcp1
     interface_uuid: if-dhcp1
-    type: dhcp
+    mode: dhcp
 
   - uuid: ns-dhcp2
     interface_uuid: if-dhcp2
-    type: dhcp
+    mode: dhcp
 
 datapath_networks:
 

--- a/integration_test/dataset/secg.yml
+++ b/integration_test/dataset/secg.yml
@@ -73,11 +73,11 @@ network_services:
 
   - uuid: ns-dhcp1
     interface_uuid: if-dhcp1
-    type: dhcp
+    mode: dhcp
 
   - uuid: ns-dhcp2
     interface_uuid: if-dhcp2
-    type: dhcp
+    mode: dhcp
 
 datapath_networks:
 

--- a/integration_test/dataset/secg_reference.yml
+++ b/integration_test/dataset/secg_reference.yml
@@ -60,7 +60,7 @@ network_services:
 
   - uuid: ns-dhcp1
     interface_uuid: if-dhcp1
-    type: dhcp
+    mode: dhcp
 
 datapath_networks:
 

--- a/integration_test/dataset/service.yml
+++ b/integration_test/dataset/service.yml
@@ -80,19 +80,19 @@ network_services:
 
   - uuid: ns-dhcp1
     interface_uuid: if-dhcp1
-    type: dhcp
+    mode: dhcp
 
   - uuid: ns-dhcp2
     interface_uuid: if-dhcp2
-    type: dhcp
+    mode: dhcp
 
   - uuid: ns-dns1
     interface_uuid: if-dns1
-    type: dns
+    mode: dns
 
   - uuid: ns-dns2
     interface_uuid: if-dns2
-    type: dns
+    mode: dns
 
 datapath_networks:
 

--- a/integration_test/dataset/simple.yml
+++ b/integration_test/dataset/simple.yml
@@ -68,11 +68,11 @@ network_services:
 
   - uuid: ns-dhcp1
     interface_uuid: if-dhcp1
-    type: dhcp
+    mode: dhcp
 
   - uuid: ns-dhcp2
     interface_uuid: if-dhcp2
-    type: dhcp
+    mode: dhcp
 
 datapath_networks:
 


### PR DESCRIPTION
Fixes network_service's 'type' to 'mode' renaming and changes the CI to use the new 'mode', while still allowing 'type' for compatibility.