### PR TITLE
Fix terminate

### DIFF
--- a/vnet/lib/vnet/core/dp_info.rb
+++ b/vnet/lib/vnet/core/dp_info.rb
@@ -205,6 +205,13 @@ module Vnet::Core
     end
 
     def internal_terminate_managers(manager_list, timeout)
+      manager_list.each { |manager|
+        begin
+          manager.terminate
+        rescue Celluloid::DeadActorError
+        end
+      }
+
       start_time = Time.new
 
       manager_list.each { |manager|

--- a/vnet/lib/vnet/openflow/controller.rb
+++ b/vnet/lib/vnet/openflow/controller.rb
@@ -37,7 +37,8 @@ module Vnet::Openflow
       info "features_reply from %#x." % dpid
 
       datapath = datapath(dpid) || return
-      datapath.switch.async.features_reply(message)
+      switch = datapath.switch || return
+      switch.async.features_reply(message)
     end
 
     def port_desc_multipart_reply(dpid, message)
@@ -57,7 +58,8 @@ module Vnet::Openflow
       debug "port_status from %#x." % dpid
 
       datapath = datapath(dpid) || return
-      datapath.switch.async.port_status(message)
+      switch = datapath.switch || return
+      switch.async.port_status(message)
     end
 
     def packet_in(dpid, message)


### PR DESCRIPTION
Properly terminate actors before trying to join, else we always wait out the 10 second timeout when switching to a new datapath.