### PR TITLE
Change fail_mode in the published docs

### DIFF
--- a/docs/content/debugging/troubleshooting.md
+++ b/docs/content/debugging/troubleshooting.md
@@ -41,7 +41,7 @@ Run `ovs-vsctl show`. The output should look similar to this.
     Bridge "br0"
         Controller "tcp:127.0.0.1:6633"
             is_connected: true
-        fail_mode: standalone
+        fail_mode: secure
         Port "inst2"
             Interface "inst2"
         Port "br0"
@@ -98,7 +98,7 @@ Run the `ovs-vsctl show` command again. Like in the section above, the output sh
     Bridge "br0"
         Controller "tcp:127.0.0.1:6633"
             is_connected: true
-        fail_mode: standalone
+        fail_mode: secure
         Port "inst2"
             Interface "inst2"
         Port "br0"

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -87,7 +87,7 @@ OVS_EXTRA="
  set bridge     ${DEVICE} other_config:disable-in-band=true --
  set bridge     ${DEVICE} other-config:datapath-id=0000aaaaaaaaaaaa --
  set bridge     ${DEVICE} other-config:hwaddr=02:01:00:00:00:01 --
- set-fail-mode  ${DEVICE} standalone --
+ set-fail-mode  ${DEVICE} secure --
  set-controller ${DEVICE} tcp:127.0.0.1:6633
 "
 ```


### PR DESCRIPTION
Cherry picked the single commit from https://github.com/axsh/openvnet/pull/446 so it can be published immediately, rather than waiting for the next OpenVNet release.