### PR TITLE
WIP: Update Trema to the latest upstream version

### DIFF
--- a/vnet/Gemfile
+++ b/vnet/Gemfile
@@ -1,9 +1,9 @@
 source "http://rubygems.org"
 
-gem 'ffi-rzmq', "1.0.3"
+gem 'ffi-rzmq'
 gem "bit-struct", ">= 0.13.7"
-gem "celluloid"
-gem "celluloid-io"
+gem "celluloid", "0.16.0"
+gem "celluloid-io", "0.16.2"
 gem "dcell"
 gem "fuguta"
 gem "ipaddress"

--- a/vnet/Gemfile
+++ b/vnet/Gemfile
@@ -1,4 +1,3 @@
-
 source "http://rubygems.org"
 
 gem 'ffi-rzmq', "1.0.3"

--- a/vnet/Gemfile.lock
+++ b/vnet/Gemfile.lock
@@ -68,9 +68,11 @@ GEM
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     fabrication (2.9.8)
-    ffi (1.9.8)
-    ffi-rzmq (1.0.3)
-      ffi
+    ffi (1.9.10)
+    ffi-rzmq (2.0.4)
+      ffi-rzmq-core (>= 1.0.1)
+    ffi-rzmq-core (1.0.4)
+      ffi (~> 1.9)
     fuguta (1.0.4)
     gli (2.0.0)
     hitimes (1.2.2)
@@ -183,13 +185,13 @@ PLATFORMS
 DEPENDENCIES
   activesupport (= 3.0.0)
   bit-struct (>= 0.13.7)
-  celluloid
-  celluloid-io
+  celluloid (= 0.16.0)
+  celluloid-io (= 0.16.2)
   coveralls
   database_cleaner
   dcell
   fabrication (= 2.9.8)
-  ffi-rzmq (= 1.0.3)
+  ffi-rzmq
   fuguta
   ipaddress
   json
@@ -214,3 +216,6 @@ DEPENDENCIES
   trema!
   unicorn
   webmock
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
Tremaを最新版にアップデートするメタな PR です。

いくつかの PR に分割して出していく予定です。上から順番にレビュー & マージしてもらえれば、すんなり行くと思います。

- [ ] #438 : Source code cosmetic changes using rubocop
- [x] #450 : Support Ubuntu 14.04
- [ ] #451 : Replace Trema::Mac with Pio::Mac

関連チケット #389, #390