### PR TITLE
Replace Trema::Mac with Pio::Mac

### DIFF
--- a/vnet/Gemfile
+++ b/vnet/Gemfile
@@ -1,10 +1,10 @@
 
 source "http://rubygems.org"
 
-gem 'ffi-rzmq', "1.0.3"
+gem 'ffi-rzmq'
 gem "bit-struct", ">= 0.13.7"
-gem "celluloid"
-gem "celluloid-io"
+gem "celluloid", "0.16.0"
+gem "celluloid-io", "0.16.2"
 gem "dcell"
 gem "fuguta"
 gem "ipaddress"

--- a/vnet/Gemfile
+++ b/vnet/Gemfile
@@ -1,4 +1,3 @@
-
 source "http://rubygems.org"
 
 gem 'ffi-rzmq'

--- a/vnet/Gemfile
+++ b/vnet/Gemfile
@@ -27,6 +27,7 @@ gem "activesupport", '3.0.0' # Updating to 4.2.1 broke the unit tests.
 gem 'paper_house', '~>0.5.0'
 gem 'rant', '>= 0.5.9', :git => 'https://github.com/axsh/rant.git'
 gem 'trema', :git=>'https://github.com/axsh/trema.git', :branch=>'wakame-edge'
+gem 'pio'
 
 group :development, :test do
   gem "rake"

--- a/vnet/Gemfile.lock
+++ b/vnet/Gemfile.lock
@@ -68,9 +68,11 @@ GEM
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     fabrication (2.9.8)
-    ffi (1.9.8)
-    ffi-rzmq (1.0.3)
-      ffi
+    ffi (1.9.10)
+    ffi-rzmq (2.0.4)
+      ffi-rzmq-core (>= 1.0.1)
+    ffi-rzmq-core (1.0.4)
+      ffi (~> 1.9)
     fuguta (1.0.4)
     gli (2.0.0)
     hitimes (1.2.2)
@@ -183,13 +185,13 @@ PLATFORMS
 DEPENDENCIES
   activesupport (= 3.0.0)
   bit-struct (>= 0.13.7)
-  celluloid
-  celluloid-io
+  celluloid (= 0.16.0)
+  celluloid-io (= 0.16.2)
   coveralls
   database_cleaner
   dcell
   fabrication (= 2.9.8)
-  ffi-rzmq (= 1.0.3)
+  ffi-rzmq
   fuguta
   ipaddress
   json
@@ -214,3 +216,6 @@ DEPENDENCIES
   trema!
   unicorn
   webmock
+
+BUNDLED WITH
+   1.11.2

--- a/vnet/Gemfile.lock
+++ b/vnet/Gemfile.lock
@@ -30,6 +30,7 @@ GEM
     activesupport (3.0.0)
     addressable (2.3.8)
     backports (3.6.4)
+    bindata (2.1.0)
     bit-struct (0.15.0)
     byebug (4.0.5)
       columnize (= 0.9.0)
@@ -96,6 +97,8 @@ GEM
     paper_house (0.5.0)
       POpen4 (~> 0.1.4)
       rake (~> 10.1.0)
+    pio (0.28.1)
+      bindata (~> 2.1.0)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -199,6 +202,7 @@ DEPENDENCIES
   net-dhcp (>= 1.1.1)
   net-dns
   paper_house (~> 0.5.0)
+  pio
   pry-byebug
   rack
   rack-cors

--- a/vnet/lib/plugins/vdc_vnet_plugin.rb
+++ b/vnet/lib/plugins/vdc_vnet_plugin.rb
@@ -4,6 +4,12 @@ require 'ipaddr'
 require 'trema'
 require 'active_support/inflector'
 
+# Remove top-level :array and :string methods introduced by trema-edge
+# to avoid the conflict with BinData's primitive methods.
+Class.class_eval { undef_method :array } rescue NameError
+Class.class_eval { undef_method :string } rescue NameError
+require 'pio'
+
 module Vnet::Plugins
   class VdcVnetPlugin
     include Celluloid
@@ -153,7 +159,7 @@ module Vnet::Plugins
     end
 
     def interface_params(vnet_params)
-      vnet_params[:mac_address] = ::Trema::Mac.new(vnet_params[:mac_address]).value if vnet_params[:mac_address]
+      vnet_params[:mac_address] = Pio::Mac.new(vnet_params[:mac_address]) if vnet_params[:mac_address]
 
       interface = if vnet_params[:ipv4_address] && vnet_params[:mac_address]
                     Vnet::NodeApi::Interface.find_all {|i|
@@ -342,7 +348,7 @@ module Vnet::Plugins
               "#{x}:#{x}:#{x}:#{x}:#{x}:#{x}"
             end
 
-      ::Trema::Mac.new(mac).value
+      Pio::Mac.new(mac)
     end
 
     def create_route_link(gw_a, gw_b)

--- a/vnet/lib/vnet/constants/openflow.rb
+++ b/vnet/lib/vnet/constants/openflow.rb
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 
 require 'ipaddr'
-require 'trema/mac'
+
+# Remove top-level :array and :string methods introduced by trema-edge
+# to avoid the conflict with BinData's primitive methods.
+Class.class_eval { undef_method :array } rescue NameError
+Class.class_eval { undef_method :string } rescue NameError
+require 'pio'
 
 module Vnet
   module Constants
@@ -15,8 +20,8 @@ module Vnet
       # Trema related constants:
       #
 
-      MAC_ZERO       = Trema::Mac.new('00:00:00:00:00:00')
-      MAC_BROADCAST  = Trema::Mac.new('ff:ff:ff:ff:ff:ff')
+      MAC_ZERO       = Pio::Mac.new('00:00:00:00:00:00')
+      MAC_BROADCAST  = Pio::Mac.new('ff:ff:ff:ff:ff:ff')
       IPV4_ZERO      = IPAddr.new('0.0.0.0')
       IPV4_BROADCAST = IPAddr.new('255.255.255.255')
 

--- a/vnet/lib/vnet/core/datapaths/base.rb
+++ b/vnet/lib/vnet/core/datapaths/base.rb
@@ -101,7 +101,7 @@ module Vnet::Core::Datapaths
         interface_id: dpn_map.interface_id || return,
         network_id: dpn_map.network_id || return,
         ip_lease_id: dpn_map.ip_lease_id,
-        mac_address: Trema::Mac.new(dpn_map.mac_address || return),
+        mac_address: Pio::Mac.new(dpn_map.mac_address || return),
 
         active: false
       }
@@ -142,7 +142,7 @@ module Vnet::Core::Datapaths
         interface_id: dprl_map.interface_id || return,
         route_link_id: dprl_map.route_link_id || return,
         ip_lease_id: dprl_map.ip_lease_id,
-        mac_address: Trema::Mac.new(dprl_map.mac_address || return),
+        mac_address: Pio::Mac.new(dprl_map.mac_address || return),
 
         active: false
       }

--- a/vnet/lib/vnet/core/interface_manager.rb
+++ b/vnet/lib/vnet/core/interface_manager.rb
@@ -163,7 +163,7 @@ module Vnet::Core
       @dp_info.filter2_manager.publish(FILTER_DEACTIVATE_INTERFACE,
                                        id: :interface,
                                        interface_id: item.id)
-      
+
       item.mac_addresses.each { |id, mac|
         @dp_info.connection_manager.async.remove_catch_new_egress(id)
         @dp_info.connection_manager.async.close_connections(id)
@@ -254,7 +254,7 @@ module Vnet::Core
 
       return unless mac_lease && mac_lease.interface_id == item.id
 
-      mac_address = Trema::Mac.new(mac_lease.mac_address)
+      mac_address = Pio::Mac.new(mac_lease.mac_address)
       item.add_mac_address(mac_lease_id: mac_lease.id,
                            mac_address: mac_address,
                            cookie_id: mac_lease.cookie_id)
@@ -295,7 +295,7 @@ module Vnet::Core
       return unless item && ip_lease.interface_id == item.id
 
       network = @dp_info.network_manager.retrieve(id: ip_lease.ip_address.network_id)
-      
+
       if network.nil?
         error log_format("could not find network for ip lease",
                          "interface_id:#{ip_lease.interface_id} network_id:#{ip_lease.ip_address.network_id}")

--- a/vnet/lib/vnet/core/interfaces/patch.rb
+++ b/vnet/lib/vnet/core/interfaces/patch.rb
@@ -122,8 +122,8 @@ module Vnet::Core::Interfaces
                            priority: 20,
 
                            actions: {
-                             :eth_src => Trema::Mac.new('00:00:27:11:11:11'),
-                             :eth_dst => Trema::Mac.new('00:00:27:22:22:22'),
+                             :eth_src => Pio::Mac.new('00:00:27:11:11:11'),
+                             :eth_dst => Pio::Mac.new('00:00:27:22:22:22'),
                            },
                            match_interface: @id,
 

--- a/vnet/lib/vnet/core/routers/base.rb
+++ b/vnet/lib/vnet/core/routers/base.rb
@@ -12,7 +12,7 @@ module Vnet::Core::Routers
       super
 
       map = params[:map]
-      @mac_address = Trema::Mac.new(map.mac_address)
+      @mac_address = Pio::Mac.new(map.mac_address)
 
       @routes = {}
     end
@@ -34,7 +34,7 @@ module Vnet::Core::Routers
     end
 
     #
-    # Events: 
+    # Events:
     #
 
     def uninstall

--- a/vnet/lib/vnet/core/translations/vnet_edge_handler.rb
+++ b/vnet/lib/vnet/core/translations/vnet_edge_handler.rb
@@ -59,7 +59,7 @@ module Vnet::Core::Translations
     def network_id_by_mac(mac_address)
       network_map = Vnet::ModelWrappers::MacAddress.batch[mac_address: mac_address].mac_lease.ip_leases.first.network.commit
 
-      debug log_format("network_id_by_mac : mac_address => #{Trema::Mac.new(mac_address)}")
+      debug log_format("network_id_by_mac : mac_address => #{Pio::Mac.new(mac_address)}")
       debug log_format("network_id_by_mac : network_map => #{network_map.inspect}")
 
       return network_map && network_map.id

--- a/vnet/lib/vnet/endpoints/1.0/helpers.rb
+++ b/vnet/lib/vnet/endpoints/1.0/helpers.rb
@@ -1,4 +1,11 @@
 # -*- coding: utf-8 -*-
+
+# Remove top-level :array and :string methods introduced by trema-edge
+# to avoid the conflict with BinData's primitive methods.
+Class.class_eval { undef_method :array } rescue NameError
+Class.class_eval { undef_method :string } rescue NameError
+require 'pio'
+
 module Vnet::Endpoints::V10::Helpers
   E = Vnet::Endpoints::Errors
 
@@ -68,8 +75,8 @@ module Vnet::Endpoints::V10::Helpers
 
     PARSE_MAC = proc do |param|
       begin
-        Trema::Mac.new(param).value
-      rescue ArgumentError
+        Pio::Mac.new(param).to_i
+      rescue Pio::Mac::InvalidValueError
         raise(E::ArgumentError, "Could not parse MAC address: #{param}")
       end
     end

--- a/vnet/lib/vnet/openflow/arp_lookup.rb
+++ b/vnet/lib/vnet/openflow/arp_lookup.rb
@@ -95,7 +95,7 @@ module Vnet::Openflow
         # Remove virtual network mode's use of db lookup until arp
         # lookup has been refactored, as the db lookups as-is won't
         # work with the active interface refactoring.
-        
+
         case ipv4_info[:network_type]
         when :physical
           arp_lookup_process_timeout(interface_mac: mac_info[:mac_address],
@@ -120,7 +120,7 @@ module Vnet::Openflow
 
       if network_conf.uuid && network_conf.uuid == network.uuid
         default_gw = network_conf.gateway && network_conf.gateway.address
-        
+
         debug log_format("arp lookup using gateway '#{default_gw}'")
 
         return IPAddr.new(default_gw) if default_gw
@@ -234,7 +234,7 @@ module Vnet::Openflow
 
       debug log_format('arp_lookup: process timeout, looking up in database',
                        "network:#{params[:interface_network_id]} ipv4_dst:#{params[:request_ipv4]} attempts:#{params[:attempts]}")
-      
+
       filter_args = {
         :ip_addresses__network_id => params[:interface_network_id],
         :ip_addresses__ipv4_address => params[:request_ipv4].to_i
@@ -248,7 +248,7 @@ module Vnet::Openflow
       end
 
       debug log_format('packet_in, found ip lease', "cookie:0x%x ipv4:#{params[:request_ipv4]}" % @arp_lookup[:reply_cookie])
-      
+
       # Load remote interface.
       interface = @dp_info.active_interface_manager.retrieve(interface_id: ip_lease.interface_id)
 
@@ -267,7 +267,7 @@ module Vnet::Openflow
                          match_network: params[:interface_network_id],
 
                          actions: {
-                           :eth_dst => Trema::Mac.new(ip_lease.mac_lease.mac_address),
+                           :eth_dst => Pio::Mac.new(ip_lease.mac_lease.mac_address),
                          },
 
                          idle_timeout: 3600,

--- a/vnet/spec/fabricators/datapath_network_fabricator.rb
+++ b/vnet/spec/fabricators/datapath_network_fabricator.rb
@@ -4,48 +4,48 @@ end
 Fabricator(:datapath_network_1_1, class_name: Vnet::Models::DatapathNetwork) do
   datapath_id 1
   network_id 1
-  mac_address Trema::Mac.new("52:54:00:00:01:01").value
+  mac_address Pio::Mac.new("52:54:00:00:01:01")
   is_connected false
 end
 
 Fabricator(:datapath_network_1_2, class_name: Vnet::Models::DatapathNetwork) do
   datapath_id 1
   network_id 2
-  mac_address Trema::Mac.new("52:54:00:00:01:02").value
+  mac_address Pio::Mac.new("52:54:00:00:01:02")
   is_connected false
 end
 
 Fabricator(:datapath_network_2_1, class_name: Vnet::Models::DatapathNetwork) do
   datapath_id 2
   network_id 1
-  mac_address Trema::Mac.new("52:54:00:00:02:01").value
+  mac_address Pio::Mac.new("52:54:00:00:02:01")
   is_connected false
 end
 
 Fabricator(:datapath_network_2_2, class_name: Vnet::Models::DatapathNetwork) do
   datapath_id 2
   network_id 2
-  mac_address Trema::Mac.new("52:54:00:00:02:02").value
+  mac_address Pio::Mac.new("52:54:00:00:02:02")
   is_connected false
 end
 
 Fabricator(:datapath_network_2_3, class_name: Vnet::Models::DatapathNetwork) do
   datapath_id 2
   network_id 3
-  mac_address Trema::Mac.new("52:54:00:00:02:03").value
+  mac_address Pio::Mac.new("52:54:00:00:02:03")
   is_connected false
 end
 
 Fabricator(:datapath_network_3_1, class_name: Vnet::Models::DatapathNetwork) do
   datapath_id 3
   network_id 1
-  mac_address Trema::Mac.new("52:54:00:00:03:01").value
+  mac_address Pio::Mac.new("52:54:00:00:03:01")
   is_connected false
 end
 
 Fabricator(:datapath_network_3_2, class_name: Vnet::Models::DatapathNetwork) do
   datapath_id 3
   network_id 2
-  mac_address Trema::Mac.new("52:54:00:00:03:02").value
+  mac_address Pio::Mac.new("52:54:00:00:03:02")
   is_connected false
 end

--- a/vnet/spec/fabricators/datapath_route_link_fabricator.rb
+++ b/vnet/spec/fabricators/datapath_route_link_fabricator.rb
@@ -4,48 +4,48 @@ end
 Fabricator(:datapath_route_link_1_1, class_name: Vnet::Models::DatapathRouteLink) do
   datapath_id 1
   route_link_id 1
-  mac_address Trema::Mac.new("52:54:00:01:01:01").value
+  mac_address Pio::Mac.new("52:54:00:01:01:01")
   is_connected false
 end
 
 Fabricator(:datapath_route_link_1_2, class_name: Vnet::Models::DatapathRouteLink) do
   datapath_id 1
   route_link_id 2
-  mac_address Trema::Mac.new("52:54:00:01:01:02").value
+  mac_address Pio::Mac.new("52:54:00:01:01:02")
   is_connected false
 end
 
 Fabricator(:datapath_route_link_2_1, class_name: Vnet::Models::DatapathRouteLink) do
   datapath_id 2
   route_link_id 1
-  mac_address Trema::Mac.new("52:54:00:01:02:01").value
+  mac_address Pio::Mac.new("52:54:00:01:02:01")
   is_connected false
 end
 
 Fabricator(:datapath_route_link_2_2, class_name: Vnet::Models::DatapathRouteLink) do
   datapath_id 2
   route_link_id 2
-  mac_address Trema::Mac.new("52:54:00:01:02:02").value
+  mac_address Pio::Mac.new("52:54:00:01:02:02")
   is_connected false
 end
 
 Fabricator(:datapath_route_link_2_3, class_name: Vnet::Models::DatapathRouteLink) do
   datapath_id 2
   route_link_id 3
-  mac_address Trema::Mac.new("52:54:00:01:02:03").value
+  mac_address Pio::Mac.new("52:54:00:01:02:03")
   is_connected false
 end
 
 Fabricator(:datapath_route_link_3_1, class_name: Vnet::Models::DatapathRouteLink) do
   datapath_id 3
   route_link_id 1
-  mac_address Trema::Mac.new("52:54:00:01:03:01").value
+  mac_address Pio::Mac.new("52:54:00:01:03:01")
   is_connected false
 end
 
 Fabricator(:datapath_route_link_3_2, class_name: Vnet::Models::DatapathRouteLink) do
   datapath_id 3
   route_link_id 2
-  mac_address Trema::Mac.new("52:54:00:01:03:02").value
+  mac_address Pio::Mac.new("52:54:00:01:03:02")
   is_connected false
 end

--- a/vnet/spec/vnet/core/tunnel_manager_spec.rb
+++ b/vnet/spec/vnet/core/tunnel_manager_spec.rb
@@ -36,7 +36,7 @@ describe Vnet::Core::TunnelManager do
 
         mac_lease = Fabricate(:mac_lease,
                               interface: interface,
-                              mac_address: Trema::Mac.new("08:00:27:00:01:0#{i}").value)
+                              mac_address: Pio::Mac.new("08:00:27:00:01:0#{i}"))
 
         ip_lease = Fabricate(:ip_lease,
                              mac_lease: mac_lease,
@@ -230,7 +230,7 @@ describe Vnet::Core::TunnelManager do
 
         mac_lease = Fabricate(:mac_lease,
                               interface: interface,
-                              mac_address: Trema::Mac.new("08:00:27:00:01:0#{i}").value)
+                              mac_address: Pio::Mac.new("08:00:27:00:01:0#{i}"))
 
         ip_lease = Fabricate(:ip_lease,
                              mac_lease: mac_lease,


### PR DESCRIPTION
This patch removes the dependency to trema-edge's Trema::Mac by replacing it with Pio::Mac.