### PR TITLE
Rpmbuild current symlink

### DIFF
--- a/deployment/packagebuild/build_packages_vnet.sh
+++ b/deployment/packagebuild/build_packages_vnet.sh
@@ -106,3 +106,5 @@ for arch in "${POSSIBLE_ARCHS[@]}"; do
 done
 
 createrepo "${repo_dir}"
+
+sudo ln -s "${repo_dir}" "${REPO_BASE_DIR}/packages/rhel/6/vnet/current"

--- a/deployment/packagebuild/build_packages_vnet.sh
+++ b/deployment/packagebuild/build_packages_vnet.sh
@@ -107,4 +107,8 @@ done
 
 createrepo "${repo_dir}"
 
-sudo ln -s "${repo_dir}" "${REPO_BASE_DIR}/packages/rhel/6/vnet/current"
+current_symlink="${REPO_BASE_DIR}/packages/rhel/6/vnet/current"
+if [ -L "${current_symlink}" ]; then
+  sudo rm "${current_symlink}"
+fi
+sudo ln -s "${repo_dir}" "${current_symlink}"


### PR DESCRIPTION
While optimizing the CI, I thought it would be a good idea to have this script create a `current` symlink for its yum repository. That way we can always point the integration test to that.