### PR TITLE
Static address with network uuid

### DIFF
--- a/client/vnctl/lib/vnctl/cli/translation.rb
+++ b/client/vnctl/lib/vnctl/cli/translation.rb
@@ -26,6 +26,10 @@ module Vnctl::Cli
          :desc => "The egress port number"
       mode.option :route_link_uuid, :type => :string,
          :desc => "The route link uuid"
+      mode.option :ingress_network_uuid, :type => :string,
+         :desc => "The uuid of the ingress network"
+      mode.option :egress_network_uuid, :type => :string,
+         :desc => "The uuid of the egress network"
     end
   end
 end

--- a/vnet/lib/vnet/endpoints/1.0/translations.rb
+++ b/vnet/lib/vnet/endpoints/1.0/translations.rb
@@ -70,7 +70,14 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/translations' do
       egress_port_number: params["egress_port_number"]
     )
 
-    respond_with(R::TranslationStaticAddress.generate(tsa))
+    r = R::TranslationStaticAddress.generate(tsa)
+
+    if params['ingress_network_uuid'] && params['egress_network_uuid']
+      r[:ingress_network_uuid] = params['ingress_network_uuid']
+      r[:egress_network_uuid] = params['egress_network_uuid']
+    end
+
+    respond_with(r)
   end
 
   static_address_shared_params

--- a/vnet/lib/vnet/endpoints/1.0/translations.rb
+++ b/vnet/lib/vnet/endpoints/1.0/translations.rb
@@ -44,6 +44,8 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/translations' do
     param :egress_ipv4_address, :String, transform: PARSE_IPV4, required: true
     param :ingress_port_number, :Integer, in: 1..65536
     param :egress_port_number, :Integer, in: 1..65536
+    param_uuid M::Network, :ingress_network_uuid
+    param_uuid M::Network, :egress_network_uuid
   end
 
   static_address_shared_params

--- a/vnet/spec/vnet/endpoints/1.0/translations_spec.rb
+++ b/vnet/spec/vnet/endpoints/1.0/translations_spec.rb
@@ -61,24 +61,6 @@ describe "/translations" do
       end
     end
 
-    shared_examples_for "with ingress/egress network uuid" do
-      context "do nothing at current moment" do
-        let(:request_params) do
-          {
-            ingress_ipv4_address: "192.168.2.10",
-            egress_ipv4_address: "192.168.2.30",
-            ingress_network_uuid: "nw-global",
-            egress_network_uuid: "nw-vnet"
-          }
-        end
-
-        it "returns ingress/egress network uuid if the parameters include them" do
-          expect(last_response).to succeed.with_body_containing(request_params)
-        end
-
-      end
-    end
-
     accepted_params = {
       ingress_ipv4_address: "192.168.2.10",
       egress_ipv4_address: "192.168.2.30",
@@ -91,15 +73,17 @@ describe "/translations" do
     describe "POST" do
       let!(:route_link) { Fabricate(:route_link, uuid: "rl-jefke") }
 
-      p_accepted_params = accepted_params.merge({route_link_uuid: "rl-jefke"})
+      p_accepted_params = accepted_params.merge({
+        route_link_uuid: "rl-jefke",
+        ingress_network_uuid: "nw-global",
+        egress_network_uuid: "nw-vnet"
+      })
 
       uuid_params = [:route_link_uuid]
 
       include_examples "POST /", p_accepted_params, required_params, uuid_params
 
       include_examples "static address mode only"
-
-      include_examples "with ingress/egress network uuid"
     end
 
     describe "DELETE" do

--- a/vnet/spec/vnet/endpoints/1.0/translations_spec.rb
+++ b/vnet/spec/vnet/endpoints/1.0/translations_spec.rb
@@ -61,6 +61,24 @@ describe "/translations" do
       end
     end
 
+    shared_examples_for "with ingress/egress network uuid" do
+      context "do nothing at current moment" do
+        let(:request_params) do
+          {
+            ingress_ipv4_address: "192.168.2.10",
+            egress_ipv4_address: "192.168.2.30",
+            ingress_network_uuid: "nw-global",
+            egress_network_uuid: "nw-vnet"
+          }
+        end
+
+        it "returns ingress/egress network uuid if the parameters include them" do
+          expect(last_response).to succeed.with_body_containing(request_params)
+        end
+
+      end
+    end
+
     accepted_params = {
       ingress_ipv4_address: "192.168.2.10",
       egress_ipv4_address: "192.168.2.30",
@@ -80,6 +98,8 @@ describe "/translations" do
       include_examples "POST /", p_accepted_params, required_params, uuid_params
 
       include_examples "static address mode only"
+
+      include_examples "with ingress/egress network uuid"
     end
 
     describe "DELETE" do


### PR DESCRIPTION
This PR is related to #460 

The endpoint accepts `ingress_network_uuid` and `egress_network_uuid` but does nothing and returns them.