### PR TITLE
Fix integration test

### DIFF
--- a/integration_test/lib/vnspec/invoker.rb
+++ b/integration_test/lib/vnspec/invoker.rb
@@ -55,8 +55,6 @@ module Vnspec
         sleep(1)
 
         SPec.exec(name)
-
-        Vnet.dump_logs
       end
     end
 

--- a/vnet/lib/vnet/core/active_port_manager.rb
+++ b/vnet/lib/vnet/core/active_port_manager.rb
@@ -73,7 +73,7 @@ module Vnet::Core
     # item created in db on queue 'item.id'
     def created_item(params)
       return if internal_detect_by_id(params)
-      return if params[:datapath_id] != @datapath_info.id
+      return if @datapath_info.nil? || params[:datapath_id] != @datapath_info.id
 
       internal_new_item(mw_class.new(params))
     end


### PR DESCRIPTION
* @rakshasa had added a feature to the integration test to dump logs. An unexpected side-effect was that now the integration test now always reported a success since it reacted to the log dump operation's exit status instead of the tests'.

  Dumping the logs per test is a good idea but I took it out for now so the integration test reports results correctly again. We can re-implement it later but fixing the integration test first is top priority.

* While the integration test wasn't reporting failures due to the above bug, a simple nilcheck bug crept in so I fixed it.