### PR TITLE
Comments for version caps in Gemfile

### DIFF
--- a/vnet/Gemfile
+++ b/vnet/Gemfile
@@ -2,6 +2,7 @@ source "http://rubygems.org"
 
 gem "ffi-rzmq", "1.0.3"
 gem "bit-struct", ">= 0.13.7"
+# Celluloid and celluloid-io versions were fixed to make OpenVNet run on Ubuntu 14.04
 gem "celluloid", "0.16.0"
 gem "celluloid-io", "0.16.2"
 gem "dcell"
@@ -29,6 +30,7 @@ gem 'rant', '>= 0.5.9', :git => 'https://github.com/axsh/rant.git'
 gem 'trema', :git=>'https://github.com/axsh/trema.git', :branch=>'wakame-edge'
 
 group :development, :test do
+  # Rake's version required was added to make OpenVNet run on Ubuntu 14.04
   gem "rake", "10.1.0"
   gem "rspec"
   gem "rack-test"


### PR DESCRIPTION
I think it's a good idea to add comments to the gemfile when we set version requirements for certain gems. I have added these comments after merging https://github.com/axsh/openvnet/pull/450 which added Ubuntu 14.04 support.