### PR TITLE
Update ruby client license

### DIFF
--- a/client/ruby/vnet_api_client.gemspec
+++ b/client/ruby/vnet_api_client.gemspec
@@ -8,5 +8,5 @@ Gem::Specification.new do |s|
   s.email       = 'dev@axsh.net'
   s.files       = Dir.glob("{lib}/**/*") + %w(README.md)
   s.homepage    = 'http://openvnet.org'
-  s.license     = 'LGPLv3'
+  s.license     = 'LGPL-3.0'
 end

--- a/client/ruby/vnet_api_client.gemspec
+++ b/client/ruby/vnet_api_client.gemspec
@@ -3,7 +3,6 @@ Gem::Specification.new do |s|
   s.version     = '0.9'
   s.date        = '2016-04-19'
   s.summary     = 'Ruby wrapper for OpenVNet\'s RESTful API'
-  s.description = s.summary
   s.authors     = ['Axsh Co. LTD']
   s.email       = 'dev@axsh.net'
   s.files       = Dir.glob("{lib}/**/*") + %w(README.md)


### PR DESCRIPTION
When pushing the vnet api client gem to rubygems.org, I saw a couple of warnings in the build log and decided to fix them.

* The license wasn't formatted properly.
* The description was the same as the summary. According to [the specification](http://guides.rubygems.org/specification-reference/), description should be a longer version of the summary. Since it is not a required field, I decided to just remove it.