### PR TITLE
Use placeholders when passing strings to Dataset#where.

### DIFF
--- a/vnet/lib/vnet/models/ip_lease.rb
+++ b/vnet/lib/vnet/models/ip_lease.rb
@@ -64,7 +64,7 @@ module Vnet::Models
     # TODO: This could cause issues if we lease/release translation
     # related ip leases often.
     def cookie_id
-      self.class.with_deleted.where(interface_id: self.interface_id).where("id <= #{self.id}").count
+      self.class.with_deleted.where(interface_id: self.interface_id).where("id <= ?", self.id).count
     end
 
   end

--- a/vnet/lib/vnet/models/mac_lease.rb
+++ b/vnet/lib/vnet/models/mac_lease.rb
@@ -16,7 +16,7 @@ module Vnet::Models
     _mac_address: :destroy
 
     def cookie_id
-      self.class.with_deleted.where(interface_id: self.interface_id).where("id <= #{self.id}").count
+      self.class.with_deleted.where(interface_id: self.interface_id).where("id <= ?", self.id).count
     end
 
   end

--- a/vnet/lib/vnet/models/security_group.rb
+++ b/vnet/lib/vnet/models/security_group.rb
@@ -35,7 +35,7 @@ module Vnet::Models
         :interface_id => interface_id).first.id
 
       SecurityGroupInterface.with_deleted.where(
-        :security_group_id => self.id).where("id <= #{row_id}").count
+        :security_group_id => self.id).where("id <= ?", row_id).count
     end
 
     def ip_addresses


### PR DESCRIPTION
I have been reading up on [Sequel's security considerations](http://sequel.jeremyevans.net/rdoc/files/doc/security_rdoc.html). We should *never* use string interpolation when passing arguments as strings to Sequel's Dataset#filter or Dataset#where methods, as it could open us op to SQL injection attacks.

The OpenVNet code only did this in 3 places with non user generated content so **is already 100% safe** against SQL injection but it would be better to just not have string interpolation in queries at all.