### PR TITLE
Update CI cluster links

### DIFF
--- a/docs/content/debugging/integration-test.md
+++ b/docs/content/debugging/integration-test.md
@@ -2,16 +2,16 @@
 
 We have an integration test environment set up for OpenVNet on which we *always* test code changes before merging them. The environment looks like this.
 
-![Integration test topology](https://github.com/wakameci/wakame-ci-cluster/raw/master/kvm-guests/90-vteskins/draw/network_structure.png)
+![Integration test topology](https://github.com/axsh/wakame-ci-cluster/raw/master/kvm-guests/90-vteskins/draw/network_structure.png)
 
 As you can see this is a pretty complicated environment. It consists of multiple KVM virtual machines, several of which have Open vSwitch and VNA running. Then there's others that act as [traditional networks](../jargon-dictionary#traditional-network), allowing us to test [VNet Edge](../jargon-dictionary#vnet-edge) among other things.
 
-This environment is portable and you can try setting it up for yourself but be aware that you will require a Linux machine capable of nested KVM. The setup scripts along with a README file can be found on [our wakameci github account](https://github.com/wakameci/wakame-ci-cluster/tree/master/kvm-guests/90-vteskins).
+This environment is portable and you can try setting it up for yourself but be aware that you will require a Linux machine capable of nested KVM. The setup scripts along with a README file can be found on [our wakame-ci-cluster repository](https://github.com/axsh/wakame-ci-cluster/tree/master/kvm-guests/90-vteskins) on github.
 
 Even if you don't set up the integration test for yourself, it can provide examples of how different virtual network topologies are set up.
 
-While the test environment setup code can be found on the wakameci account, the integration code itself is located [in the OpenVNet repository](https://github.com/axsh/openvnet/tree/master/integration_test) itself.
+While the test environment setup scripts can be found in the wakame-ci-cluster repository, the test code itself is located [in the OpenVNet repository](https://github.com/axsh/openvnet/tree/master/integration_test) itself.
 
-The dataset directory in there contains yaml files that translate directly to `vnctl` commands. The file [dataset/base.yml](https://github.com/axsh/openvnet/blob/master/integration_test/dataset/base.yml) will show you you how to configure a multi-host OpenVNet setup. while all the other files in that directory create various virtual network topologies.
+The dataset directory in there contains yaml files that translate directly to `vnctl` commands. The file [dataset/base.yml](https://github.com/axsh/openvnet/blob/master/integration_test/dataset/base.yml) will show you you how to configure a multi-host OpenVNet setup. While all the other files in that directory create various virtual network topologies.
 
 Figuring out the integration test environment can be a daunting task at first but it's the best resource after completing the guides on this site. Good luck.

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -1,7 +1,6 @@
 Integration Tests
 =================
 
-OpenVNet provides a set of integration tests that can be run on virtual machines. To deploy the test environment follow the instructions on the pages below.
+OpenVNet provides a set of integration tests that can be run on virtual machines. To deploy the test environment follow the instructions on the page below.
 
-* https://github.com/wakameci/wakame-ci-cluster/blob/master/README.md
-* https://github.com/wakameci/wakame-ci-cluster/blob/master/kvm-guests/90-vteskins/README.md
+* https://github.com/axsh/wakame-ci-cluster/blob/master/kvm-guests/90-vteskins/README.md

--- a/integration_test/bin/dev-spec
+++ b/integration_test/bin/dev-spec
@@ -1,6 +1,3 @@
 #!/bin/bash
 
-# The dev.yml setting is for running integration-test on local PC.
-# Detail: https://github.com/wakameci/wakame-ci-cluster/tree/feature-support_openvnet-testspec_devenv/kvm-guests/192.168.3.90-vteskins
-
 VNSPEC_ENV=dev $(dirname ${BASH_SOURCE[0]})/vnspec $*


### PR DESCRIPTION
There was some documentation that still pointed at the old location of the wakame-ci-cluster scripts. Updated those.

This can skip the CI since only documentation and README files are changed.