### PR TITLE
Remote OVS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * `Added` A new features called `segment` that accurately simulates L2 segments, allowing connected interfaces to freely set and change their IP addresses without making OpenVNet aware of them.
 
+* `Added` The option to have VNA take control of an Open vSwitch running on another host.
+
 * `Changed` It is no longer possibly to directly modify an IP lease through the WebAPI. In order to preserve network state history, IP leases need to be deleted and recreated.
 
 * `Changed` We now use the [PIO](https://github.com/trema/pio) library to manage MAC addresses.

--- a/deployment/conf_files/etc/openvnet/vna.conf
+++ b/deployment/conf_files/etc/openvnet/vna.conf
@@ -38,10 +38,23 @@ network {
 
 #
 # switch : The switch for VNA to connect when using the ovs-ofctl or ovs-vsctl commands.
-#          This is intended to be used when VNA needs to take control of an OVS running on a different host.
-#          If not provided VNA will use the Datapath ID in the database to connect to the correct local OVS.
+#          If not provided VNA will use the Datapath ID in the database to looks for an instance of OVS
+#          running on the same host as VNA.
+#
+#          The value of `switch` will be fed directly to the ovs-ofctl command and thus supports any format
+#          that ovs-ofctl can take.
+#
+#          ssl:ip[:port]
+#          tcp:ip[:port]
+#          unix:file
+#          bridge
+#          [type@]dp
 #
 #          Example: 'tcp:192.168.3.101:6653'
+#          Example: 'ssl:172.16.15.100:6653'
+#          Example: 'br1'
+#
+#          Check the ovs-ofctl man page for more details.
 #
 
 #switch ''
@@ -50,7 +63,21 @@ network {
 # ovsdb : This option can be used to make VNA connect to a remote OVSDB running on another host. If OVSDB is
 #         running locally which is the most common case, this option can be omitted.
 #
+#         The value of `ovsdb` will be fed directly to the ovs-vsctl command's --db= parameter. Therefore it
+#         supports any format `ovs-vsctl --db=` supports
+#
+#         ssl:ip:port
+#         tcp:ip:port
+#         unix:file
+#         pssl:port[:ip]
+#            The  --private-key, --certificate, and
+#            --ca-cert options are mandatory when this form is used.
+#         ptcp:port[:ip]
+#         punix:file
+#
 #         Example: 'tcp:192.168.3.101:6640'
+#
+#         Check the ovs-vsctl man page for more details.
 #
 
 #ovsdb ''

--- a/deployment/conf_files/etc/openvnet/vna.conf
+++ b/deployment/conf_files/etc/openvnet/vna.conf
@@ -35,3 +35,22 @@ network {
     address ""
   }
 }
+
+#
+# switch : The switch for VNA to connect when using the ovs-ofctl or ovs-vsctl commands.
+#          This is intended to be used when VNA needs to take control of an OVS running on a different host.
+#          If not provided VNA will use the Datapath ID in the database to connect to the correct local OVS.
+#
+#          Example: 'tcp:192.168.3.101:6653'
+#
+
+#switch ''
+
+#
+# ovsdb : This option can be used to make VNA connect to a remote OVSDB running on another host. If OVSDB is
+#         running locally which is the most common case, this option can be omitted.
+#
+#         Example: 'tcp:192.168.3.101:6640'
+#
+
+#ovsdb ''

--- a/docs/content/configuration-files/vna.md
+++ b/docs/content/configuration-files/vna.md
@@ -62,3 +62,21 @@ The uuid of the public/physical network in which the vna participates.
 * address
 
 The gateway address of the network specified by the 'uuid'.
+
+## Misc
+
+```ruby
+switch 'tcp:192.168.3.101:6653'
+```
+
+* switch
+
+The switch for VNA to connect when using the ovs-ofctl or ovs-vsctl commands. This is intended to be used when VNA needs to take control of an OVS running on a different host. If not provided VNA will use the Datapath ID in the database to connect to the correct local OVS.
+
+```ruby
+ovsdb 'tcp:192.168.3.101:6640'
+```
+
+* ovsdb
+
+This option can be used to make VNA connect to a remote OVSDB running on another host. If OVSDB is running locally which is the most common case, this option can be omitted.

--- a/vnet/bin/vnflows-monitor
+++ b/vnet/bin/vnflows-monitor
@@ -361,6 +361,7 @@ Options.opts[:pretty] = 1
 Options.opts[:time] = 2
 Options.opts[:run] = 0
 Options.opts[:iteration] = []
+Options.opts[:switch] = 'br0'
 
 OptionParser.new do |op|
   op.on("-c", "--count N", Float, "Number of iterations, 0 = keep going (default 1)") do |c|
@@ -384,6 +385,9 @@ OptionParser.new do |op|
   op.on("-i", "--iteration x,y", Array, "Pull flows from iteration number x. y") do |i|
     Options.opts[:iteration] = i
   end
+  op.on("-s", "--switch X", String, "The name of the switch to dump flows of. [br1, tcp:10.0.0.10:6653, ...] (default br0)") do |s|
+    Options.opts[:switch] = s
+  end
 end.parse!
 Options.count = 0
 Options.prevflows = nil
@@ -405,9 +409,9 @@ def latest_run_number
   alln.max
 end
 
-def read_current_table(run_n)
+def read_current_table(run_n, switch)
   Options.inputcount += 1
-  $cmdline = "ovs-ofctl -O OpenFlow13 dump-flows br0"
+  $cmdline = "ovs-ofctl -O OpenFlow13 dump-flows #{switch}"
   system("#{$cmdline} >/tmp/vnflows-run-#{run_n}/flow-#{Options.inputcount}")
 end
 
@@ -532,7 +536,7 @@ end
 
 Options.run_n = choose_run_number
 while true  # note the "exit"s elsewhere
-  read_current_table(Options.run_n)
+  read_current_table(Options.run_n, Options.opts[:switch])
   parse_raw_table(Options.run_n, Options.inputcount)  # sets globals
   flows = choose_flows # uses globals
   output_flows(flows)

--- a/vnet/lib/vnet/configurations/vna.rb
+++ b/vnet/lib/vnet/configurations/vna.rb
@@ -48,6 +48,9 @@ module Vnet::Configurations
     param :node_api_proxy, :default => :rpc
     param :trema_home, :default => Gem::Specification.find_by_name('trema').gem_dir
     param :trema_tmp, :default => '/var/run/openvnet'
+
+    param :switch
+    param :ovsdb
   end
 
 end

--- a/vnet/lib/vnet/openflow/ovs_ofctl.rb
+++ b/vnet/lib/vnet/openflow/ovs_ofctl.rb
@@ -101,7 +101,7 @@ module Vnet::Openflow
             when :no_receive then 'no-receive'
             end
 
-      port_no = switch_name if port_no == Controller::OFPP_LOCAL
+      port_no = get_bridge_name(@dpid) if port_no == Controller::OFPP_LOCAL
 
       system("#{@ovs_ofctl_10} mod-port #{switch_name} #{port_no} #{arg}")
     end

--- a/vnet/lib/vnet/openflow/ovs_ofctl.rb
+++ b/vnet/lib/vnet/openflow/ovs_ofctl.rb
@@ -21,7 +21,6 @@ module Vnet::Openflow
 
       @switch_name = conf.switch || get_bridge_name(datapath_id)
 
-      # @verbose = Dcmgr.conf.verbose_openflow
       @verbose = false
     end
 

--- a/vnet/lib/vnet/openflow/ovs_ofctl.rb
+++ b/vnet/lib/vnet/openflow/ovs_ofctl.rb
@@ -12,14 +12,14 @@ module Vnet::Openflow
       @dpid = datapath_id
       @dpid_s = "0x%016x" % @dpid
 
-      # TODO: Make ovs_vsctl use a real config option.
       conf = Vnet::Configurations::Vna.conf
-      # @ovs_ofctl = conf.ovs_ofctl_path
-      # @ovs_vsctl = conf.ovs_vsctl_path
+
       @ovs_ofctl = 'ovs-ofctl -O OpenFlow13'
       @ovs_ofctl_10 = 'ovs-ofctl -O OpenFlow10'
       @ovs_vsctl = 'ovs-vsctl'
-      @switch_name = get_bridge_name(datapath_id)
+      @ovs_vsctl += " --db=#{conf.ovsdb}" if conf.ovsdb
+
+      @switch_name = conf.switch || get_bridge_name(datapath_id)
 
       # @verbose = Dcmgr.conf.verbose_openflow
       @verbose = false

--- a/vnet/lib/vnet/openflow/ovs_ofctl.rb
+++ b/vnet/lib/vnet/openflow/ovs_ofctl.rb
@@ -114,13 +114,17 @@ module Vnet::Openflow
       command << " options:remote_ip=#{params[:remote_ip]}" if params[:remote_ip]
       command << " options:local_ip=#{params[:local_ip]}" if params[:local_ip]
 
+      debug command if verbose
+
       system(command)
     end
 
     def delete_tunnel(tunnel_name)
       debug log_format('delete tunnel', "#{tunnel_name}")
 
-      system("#{@ovs_vsctl} del-port #{switch_name} #{tunnel_name}")
+      command = "#{@ovs_vsctl} del-port #{switch_name} #{tunnel_name}"
+      debug command if verbose
+      system(command)
     end
 
     #

--- a/vnet/spec/config/vna.conf
+++ b/vnet/spec/config/vna.conf
@@ -7,3 +7,6 @@ node {
   }
 }
 node_api_proxy :rpc
+
+switch "tcp:172.16.50.2:6653"
+ovsdb "tcp:172.16.55.1:6666"

--- a/vnet/spec/vnet/configurations/vna_spec.rb
+++ b/vnet/spec/vnet/configurations/vna_spec.rb
@@ -21,5 +21,8 @@ describe Vnet::Configurations::Vna do
     # trema
     it { expect(subject.trema_home).to eq Gem::Specification.find_by_name('trema').gem_dir }
     it { expect(subject.trema_tmp).to eq "/var/run/openvnet" }
+
+    it { expect(subject.switch).to eq "tcp:172.16.50.2:6653" }
+    it { expect(subject.ovsdb).to eq "tcp:172.16.55.1:6666" }
   end
 end


### PR DESCRIPTION
Allows VNA to take control of an Open vSwitch instance running on another host.