### PR TITLE
RHEL7/CentOS7 support

### DIFF
--- a/deployment/conf.el7/etc/sysconfig/openvnet
+++ b/deployment/conf.el7/etc/sysconfig/openvnet
@@ -1,0 +1,5 @@
+# OpenVNet common variables
+VNET_ROOT=/opt/axsh/openvnet
+RUBY_PATH=/opt/axsh/openvnet/ruby/bin
+PATH=${RUBY_PATH}:$PATH
+LOG_DIRECTORY=/var/log/openvnet/

--- a/deployment/conf.el7/etc/systemd/system/vnet-webapi.service.d/env.conf
+++ b/deployment/conf.el7/etc/systemd/system/vnet-webapi.service.d/env.conf
@@ -1,0 +1,2 @@
+[Service]
+#Environment=BIND_ADDR=127.0.0.1 PORT=9090 RACK_ENV=production

--- a/deployment/conf.el7/usr/lib/systemd/system/vnet-vna.service
+++ b/deployment/conf.el7/usr/lib/systemd/system/vnet-vna.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=OpenVNet agent process
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/default/openvnet
+WorkingDirectory=${VNET_ROOT}/vnet
+ExecStart=/opt/axsh/openvnet/ruby/bin/bundle exec ./bin/vna >> ${LOG_DIRECTORY}/vna.log
+
+
+[Install]
+WantedBy=multi-user.target

--- a/deployment/conf.el7/usr/lib/systemd/system/vnet-vna.service
+++ b/deployment/conf.el7/usr/lib/systemd/system/vnet-vna.service
@@ -3,7 +3,7 @@ Description=OpenVNet agent process
 After=network.target
 
 [Service]
-EnvironmentFile=/etc/default/openvnet
+EnvironmentFile=/etc/sysconfig/openvnet
 WorkingDirectory=${VNET_ROOT}/vnet
 ExecStart=/opt/axsh/openvnet/ruby/bin/bundle exec ./bin/vna >> ${LOG_DIRECTORY}/vna.log
 

--- a/deployment/conf.el7/usr/lib/systemd/system/vnet-vnmgr.service
+++ b/deployment/conf.el7/usr/lib/systemd/system/vnet-vnmgr.service
@@ -3,7 +3,7 @@ Description=OpenVNet management process
 After=network.target
 
 [Service]
-EnvironmentFile=/etc/default/openvnet
+EnvironmentFile=/etc/sysconfig/openvnet
 User=vnet-vnmgr
 WorkingDirectory=${VNET_ROOT}/vnet
 ExecStart=/opt/axsh/openvnet/ruby/bin/bundle exec ./bin/vnmgr >> ${LOG_DIRECTORY}/vnmgr.log

--- a/deployment/conf.el7/usr/lib/systemd/system/vnet-vnmgr.service
+++ b/deployment/conf.el7/usr/lib/systemd/system/vnet-vnmgr.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=OpenVNet management process
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/default/openvnet
+User=vnet-vnmgr
+WorkingDirectory=${VNET_ROOT}/vnet
+ExecStart=/opt/axsh/openvnet/ruby/bin/bundle exec ./bin/vnmgr >> ${LOG_DIRECTORY}/vnmgr.log
+
+[Install]
+WantedBy=multi-user.target

--- a/deployment/conf.el7/usr/lib/systemd/system/vnet-webapi.service
+++ b/deployment/conf.el7/usr/lib/systemd/system/vnet-webapi.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=OpenVNet REST API process
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/default/openvnet
+Environment=BIND_ADDR=0.0.0.0 PORT=9090 RACK_ENV=production
+User=vnet-webapi
+WorkingDirectory=${VNET_ROOT}/vnet
+ExecStart=/opt/axsh/openvnet/ruby/bin/bundle exec unicorn -o ${BIND_ADDR} -p ${PORT} ./rack/config-webapi.ru >> ${LOG_DIRECTORY}/webapi.log
+
+
+[Install]
+WantedBy=multi-user.target

--- a/deployment/conf.el7/usr/lib/systemd/system/vnet-webapi.service
+++ b/deployment/conf.el7/usr/lib/systemd/system/vnet-webapi.service
@@ -3,7 +3,7 @@ Description=OpenVNet REST API process
 After=network.target
 
 [Service]
-EnvironmentFile=/etc/default/openvnet
+EnvironmentFile=/etc/sysconfig/openvnet
 Environment=BIND_ADDR=0.0.0.0 PORT=9090 RACK_ENV=production
 User=vnet-webapi
 WorkingDirectory=${VNET_ROOT}/vnet

--- a/deployment/packagebuild/build_packages_vnet.sh
+++ b/deployment/packagebuild/build_packages_vnet.sh
@@ -11,6 +11,7 @@ OPENVNET_SRC_ROOT_DIR="$( cd "${current_dir}/../.."; pwd )"
 WORK_DIR="${WORK_DIR:-/tmp/vnet-rpmbuild}"
 REPO_BASE_DIR="${REPO_BASE_DIR:-/var/www/html/repos}"
 POSSIBLE_ARCHS=( 'x86_64' 'i386' 'noarch' )
+RHEL_RELVER="${RHEL_RELVER:-$(rpm --eval '%{rhel}')}"
 
 function check_dependency() {
   local cmd="$1"
@@ -70,7 +71,7 @@ git clean -xdf
 
 if [ "$BUILD_TYPE" == "stable" ]; then
   # If we're building a stable version we must make sure we checkout the correct version of the code.
-  repo_dir="${REPO_BASE_DIR}/packages/rhel/6/vnet/${RPM_VERSION}"
+  repo_dir="${REPO_BASE_DIR}/packages/rhel/${RHEL_RELVER}/vnet/${RPM_VERSION}"
 
   git checkout "${RPM_VERSION}"
   echo "Building the following commit for stable version ${RPM_VERSION}"
@@ -82,7 +83,7 @@ else
   timestamp=$(date --date="$(git show -s --format=%cd --date=iso HEAD)" +%Y%m%d%H%M%S)
   RELEASE_SUFFIX="${timestamp}git$(git rev-parse --short HEAD)"
 
-  repo_dir="${REPO_BASE_DIR}/packages/rhel/6/vnet/${RELEASE_SUFFIX}"
+  repo_dir="${REPO_BASE_DIR}/packages/rhel/${RHEL_RELVER}/vnet/${RELEASE_SUFFIX}"
 
   rpmbuild -ba --define "_topdir ${WORK_DIR}" --define "dev_release_suffix ${RELEASE_SUFFIX}" "${OPENVNET_SPEC_FILE}"
 fi

--- a/deployment/packagebuild/build_packages_vnet.sh
+++ b/deployment/packagebuild/build_packages_vnet.sh
@@ -13,13 +13,12 @@ REPO_BASE_DIR="${REPO_BASE_DIR:-/var/www/html/repos}"
 POSSIBLE_ARCHS=( 'x86_64' 'i386' 'noarch' )
 RHEL_RELVER="${RHEL_RELVER:-$(rpm --eval '%{rhel}')}"
 
-function check_dependency() {
-  local cmd="$1"
-  local pkg="$2"
-
-  command -v ${cmd} >/dev/null 2>&1 || {
-    sudo yum install -y ${pkg}
-  }
+function yum_check_install() {
+  for i in $*; do
+    if ! rpm -q $i &> /dev/null; then
+      echo $i
+    fi
+  done | xargs --no-run-if-empty yum install -y
 }
 
 if [ "${BUILD_TYPE}" == "stable" ] && [ -z "${RPM_VERSION}" ]; then
@@ -32,8 +31,7 @@ fi
 # Install dependencies
 #
 
-check_dependency yum-builddep yum-utils
-check_dependency createrepo createrepo
+yum_check_install yum-utils createrepo rpmdevtools
 
 # Make sure that we work with the correct version of openvnet-ruby
 sudo cp "${current_dir}/../yum_repositories/${BUILD_TYPE}/openvnet-third-party.repo" /etc/yum.repos.d

--- a/deployment/packagebuild/build_packages_vnet.sh
+++ b/deployment/packagebuild/build_packages_vnet.sh
@@ -68,6 +68,7 @@ git clean -xdf
 #
 # Build the packages
 #
+export PATH="/opt/axsh/openvnet/ruby/bin:$PATH"
 
 if [ "$BUILD_TYPE" == "stable" ]; then
   # If we're building a stable version we must make sure we checkout the correct version of the code.

--- a/deployment/packagebuild/packages.d/vnet/openvnet.spec
+++ b/deployment/packagebuild/packages.d/vnet/openvnet.spec
@@ -2,6 +2,7 @@
 # development (non stable) versions.
 %define release 1
 %{?dev_release_suffix:%define release %{dev_release_suffix}}
+%define strip_vendor %{?strip_vendor:1}
 
 Name: openvnet
 Version: 0.9%{?dev_release_suffix:dev}
@@ -74,11 +75,22 @@ cp "$OPENVNET_SRC_DIR"/vnet/bin/vnflows-monitor "$RPM_BUILD_ROOT"/opt/axsh/openv
 cp "$OPENVNET_SRC_DIR"/vnet/bin/vnmgr "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/bin/
 cp -r "$OPENVNET_SRC_DIR"/vnet/db "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
 cp -r "$OPENVNET_SRC_DIR"/vnet/lib "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
-cp -r "$OPENVNET_SRC_DIR"/vnet/vendor "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
 cp -r "$OPENVNET_SRC_DIR"/vnet/.bundle "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
 cp -r "$OPENVNET_SRC_DIR"/vnet/rack "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet
 cp -r "$OPENVNET_SRC_DIR"/client/vnctl "$RPM_BUILD_ROOT"/opt/axsh/openvnet/client/
-
+%if %{strip_vendor}
+tar cO --directory="${OPENVNET_SRC_DIR}/vnet" \
+  --exclude='*.o' \
+  --exclude='.git' \
+  --exclude='cache/*.gem' \
+  --exclude='gems/*-*/test/*' \
+  --exclude='gems/*-*/spec/*' \
+  --exclude='gems/*-*/doc/*' \
+  --exclude='gems/pio-*/features/*' \
+  vendor/ | tar -x --directory="${RPM_BUILD_ROOT}/opt/axsh/openvnet/vnet" -f -
+%else
+cp -r "$OPENVNET_SRC_DIR"/vnet/vendor "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
+%endif
 
 %package common
 #

--- a/deployment/packagebuild/packages.d/vnet/openvnet.spec
+++ b/deployment/packagebuild/packages.d/vnet/openvnet.spec
@@ -144,6 +144,7 @@ This package contains OpenVNet's Restful WebAPI. Users can interact with OpenVNe
 %config(noreplace) /etc/openvnet/webapi.conf
 %if %{defined systemd_requires}
 %config %{_unitdir}/vnet-webapi.service
+%config(noreplace) /etc/systemd/system/vnet-webapi.service.d/env.conf
 %else
 %config(noreplace) /etc/default/vnet-webapi
 %config /etc/init/vnet-webapi.conf

--- a/deployment/packagebuild/packages.d/vnet/openvnet.spec
+++ b/deployment/packagebuild/packages.d/vnet/openvnet.spec
@@ -79,11 +79,12 @@ cp -r "$OPENVNET_SRC_DIR"/vnet/.bundle "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
 cp -r "$OPENVNET_SRC_DIR"/vnet/rack "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet
 cp -r "$OPENVNET_SRC_DIR"/client/vnctl "$RPM_BUILD_ROOT"/opt/axsh/openvnet/client/
 
+
+%package common
 #
 # openvnet-common package
 #
 
-%package common
 Summary: Common code for all OpenVNet services.
 
 # We turn off automatic dependecy detection because rpmbuild will see some
@@ -124,11 +125,11 @@ This package contains all the common code for OpenVNet's services. All of the Op
 %config(noreplace) /etc/default/openvnet
 %endif
 
+%package webapi
 #
 # openvnet-webapi package
 #
 
-%package webapi
 Summary: OpenVNet's RESTful WebAPI.
 BuildArch: noarch
 
@@ -167,11 +168,11 @@ chown "$user"."$user" "$logfile"
 %preun webapi
 %{?systemd_preun:%systemd_preun vnet-webapi.service}
 
+%package vnmgr
 #
 # openvnet-vnmgr package
 #
 
-%package vnmgr
 Summary: Virtual Network Manager for OpenVNet.
 BuildArch: noarch
 
@@ -210,11 +211,10 @@ chown "$user"."$user" "$logfile"
 %preun vnmgr
 %{?systemd_preun:%systemd_preun vnet-vnmgr.service}
 
+%package vna
 #
 # openvnet-vna package
 #
-
-%package vna
 
 Summary: Virtual network agent for OpenVNet.
 BuildArch: noarch
@@ -246,11 +246,10 @@ This package contains OpenVNet's VNA process. This is an OpenFlow controller tha
 %preun vna
 %{?systemd_preun:%systemd_preun vnet-vna.service}
 
+%package vnctl
 #
 # openvnet-vnctl package
 #
-
-%package vnctl
 
 Summary: A commandline client for OpenVNet's WebAPI.
 BuildArch: noarch

--- a/deployment/packagebuild/packages.d/vnet/openvnet.spec
+++ b/deployment/packagebuild/packages.d/vnet/openvnet.spec
@@ -37,19 +37,25 @@ Requires: openvnet-vna
 %description
 This is an empty metapackage that depends on all OpenVNet services and the vnctl client. Just a conventient way to install everything at once on a single machine.
 
+%files
+# No files in the openvnet metapackage.
+
 %prep
 OPENVNET_SRC_DIR="$RPM_SOURCE_DIR/openvnet"
-BUNDLE_PATH="/opt/axsh/openvnet/ruby/bin/bundle"
 if [ ! -d "$OPENVNET_SRC_DIR" ]; then
   git clone https://github.com/axsh/openvnet "$OPENVNET_SRC_DIR"
 fi
-cd "$OPENVNET_SRC_DIR/vnet"
-"$BUNDLE_PATH" install --path vendor/bundle --without development test --standalone
-cd "$OPENVNET_SRC_DIR/client/vnctl"
-"$BUNDLE_PATH" install --path vendor/bundle --without development test --standalone
 
-%files
-# No files in the openvnet metapackage.
+%build
+cd "$RPM_SOURCE_DIR/openvnet"
+(
+  cd "vnet"
+  bundle install --path vendor/bundle --without development test --standalone
+)
+(
+  cd "client/vnctl"
+  bundle install --path vendor/bundle --without development test --standalone
+)
 
 %install
 OPENVNET_SRC_DIR="$RPM_SOURCE_DIR/openvnet"

--- a/deployment/packagebuild/packages.d/vnet/openvnet.spec
+++ b/deployment/packagebuild/packages.d/vnet/openvnet.spec
@@ -58,33 +58,33 @@ cd "$RPM_SOURCE_DIR/openvnet"
 )
 
 %install
-OPENVNET_SRC_DIR="$RPM_SOURCE_DIR/openvnet"
+cd "$RPM_SOURCE_DIR/openvnet"
 mkdir -p "$RPM_BUILD_ROOT"/etc
 mkdir -p "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/bin
 mkdir -p "$RPM_BUILD_ROOT"/opt/axsh/openvnet/client
 mkdir -p "$RPM_BUILD_ROOT"/var/log/openvnet
 mkdir -p "$RPM_BUILD_ROOT"/usr/bin
 %if %{defined systemd_requires}
-cp -r "$OPENVNET_SRC_DIR"/deployment/conf.el7/* "$RPM_BUILD_ROOT"/
+cp -r deployment/conf.el7/* "$RPM_BUILD_ROOT"/
 %else
-cp -r "$OPENVNET_SRC_DIR"/deployment/conf_files/etc/default "$RPM_BUILD_ROOT"/etc/
-cp -r "$OPENVNET_SRC_DIR"/deployment/conf_files/etc/init "$RPM_BUILD_ROOT"/etc/
+cp -r deployment/conf_files/etc/default "$RPM_BUILD_ROOT"/etc/
+cp -r deployment/conf_files/etc/init "$RPM_BUILD_ROOT"/etc/
 %endif
-cp -r "$OPENVNET_SRC_DIR"/deployment/conf_files/etc/openvnet "$RPM_BUILD_ROOT"/etc/
-cp "$OPENVNET_SRC_DIR"/deployment/conf_files/usr/bin/vnctl "$RPM_BUILD_ROOT"/usr/bin/
-cp "$OPENVNET_SRC_DIR"/vnet/Gemfile "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
-cp "$OPENVNET_SRC_DIR"/vnet/Gemfile.lock "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
-cp "$OPENVNET_SRC_DIR"/vnet/LICENSE "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
-cp "$OPENVNET_SRC_DIR"/vnet/README.md "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
-cp "$OPENVNET_SRC_DIR"/vnet/Rakefile "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
-cp "$OPENVNET_SRC_DIR"/vnet/bin/vna "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/bin/
-cp "$OPENVNET_SRC_DIR"/vnet/bin/vnflows-monitor "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/bin/
-cp "$OPENVNET_SRC_DIR"/vnet/bin/vnmgr "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/bin/
-cp -r "$OPENVNET_SRC_DIR"/vnet/db "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
-cp -r "$OPENVNET_SRC_DIR"/vnet/lib "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
-cp -r "$OPENVNET_SRC_DIR"/vnet/.bundle "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
-cp -r "$OPENVNET_SRC_DIR"/vnet/rack "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet
-cp -r "$OPENVNET_SRC_DIR"/client/vnctl "$RPM_BUILD_ROOT"/opt/axsh/openvnet/client/
+cp -r deployment/conf_files/etc/openvnet "$RPM_BUILD_ROOT"/etc/
+install -m 755 deployment/conf_files/usr/bin/vnctl "$RPM_BUILD_ROOT"/usr/bin/
+cp vnet/Gemfile "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
+cp vnet/Gemfile.lock "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
+cp vnet/LICENSE "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
+cp vnet/README.md "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
+cp vnet/Rakefile "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
+install -m 755 vnet/bin/vna "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/bin/
+install -m 755 vnet/bin/vnflows-monitor "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/bin/
+install -m 755 vnet/bin/vnmgr "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/bin/
+cp -r vnet/db "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
+cp -r vnet/lib "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
+cp -r vnet/.bundle "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
+cp -r vnet/rack "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet
+cp -r client/vnctl "$RPM_BUILD_ROOT"/opt/axsh/openvnet/client/
 %if %{strip_vendor}
 tar cO --directory="${OPENVNET_SRC_DIR}/vnet" \
   --exclude='*.o' \
@@ -96,7 +96,7 @@ tar cO --directory="${OPENVNET_SRC_DIR}/vnet" \
   --exclude='gems/pio-*/features/*' \
   vendor/ | tar -x --directory="${RPM_BUILD_ROOT}/opt/axsh/openvnet/vnet" -f -
 %else
-cp -r "$OPENVNET_SRC_DIR"/vnet/vendor "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
+cp -r vnet/vendor "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
 %endif
 
 %package common

--- a/deployment/packagebuild/packages.d/vnet/openvnet.spec
+++ b/deployment/packagebuild/packages.d/vnet/openvnet.spec
@@ -3,6 +3,7 @@
 %define release 1
 %{?dev_release_suffix:%define release %{dev_release_suffix}}
 %define strip_vendor %{?strip_vendor:1}
+%define openvnet_ruby_ver %{?openvnet_ruby_ver:2.1.10}
 
 Name: openvnet
 Version: 0.9%{?dev_release_suffix:dev}
@@ -26,7 +27,7 @@ BuildRequires: libpcap-devel
 
 # We require openvnet-ruby to run bundle install.
 # By using openvnet-ruby we ensure that the downloaded gems are compatible.
-BuildRequires: openvnet-ruby = 2.1.1.axsh0
+BuildRequires: openvnet-ruby = %{openvnet_ruby_ver}
 
 Requires: openvnet-vnctl
 Requires: openvnet-webapi
@@ -105,7 +106,8 @@ AutoReqProv: no
 
 Requires: zeromq3
 Requires: mysql-libs
-Requires: openvnet-ruby
+# Runtime openvnet-ruby version must be same as building package.
+Requires: openvnet-ruby = %{openvnet_ruby_ver}
 
 # The zeromq3-devel package is required because it provides the /usr/lib64/libzmq.so file.
 # That file is just a symlink to /usr/lib64/libzmq.so.3.0.0 which is provided by the zerom13

--- a/deployment/packagebuild/packages.d/vnet/openvnet.spec
+++ b/deployment/packagebuild/packages.d/vnet/openvnet.spec
@@ -86,7 +86,7 @@ cp -r vnet/.bundle "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet/
 cp -r vnet/rack "$RPM_BUILD_ROOT"/opt/axsh/openvnet/vnet
 cp -r client/vnctl "$RPM_BUILD_ROOT"/opt/axsh/openvnet/client/
 %if %{strip_vendor}
-tar cO --directory="${OPENVNET_SRC_DIR}/vnet" \
+tar cO --directory="vnet" \
   --exclude='*.o' \
   --exclude='.git' \
   --exclude='cache/*.gem' \


### PR DESCRIPTION
- [x] Exclude *.o from common.rpm.
- [x] Add /etc/systemd/system/vnet-webapi.service.d/env.conf as an exmaple for local modification.

### issues

- CentOS6.6 or later fails at kmod-openvswitch installation. Need to upgrade to openvswith-2.4.0 since the version removed the dependency to the kmod package.
- openvnet-ruby for CentOS7 on third party is broken in the shebang path.  ``yum install -y openvnet`` test is failing.  