### PR TITLE
Apply Editor Config style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.go]
+indent_style = tab


### PR DESCRIPTION
[Editor Config](http://editorconfig.org/) helps to force to apply the formatting style to the source files on the supported text editors.

I acts development on Windows so that the editor has to be configured to use LF for newline code.