### PR TITLE
Remove physical DHCP from integration test

### DIFF
--- a/integration_test/config/default.yml
+++ b/integration_test/config/default.yml
@@ -32,10 +32,8 @@ dataset_options:
   edge_ipv4_address: 172.16.20.21
   public_ipv4_public1_network: 172.16.20.0
   public_ipv4_public1_prefix: 24
-  public_ipv4_public1_dhcp_address: 172.16.20.3
   public_ipv4_public2_network: 172.16.30.0
   public_ipv4_public2_prefix: 24
-  public_ipv4_public2_dhcp_address: 172.16.30.3
   public_ipv4_address1: 172.16.20.201
   public_ipv4_address2: 172.16.20.202
   public_router_ipv4_address: 172.16.20.102

--- a/integration_test/config/dev.yml
+++ b/integration_test/config/dev.yml
@@ -24,10 +24,8 @@ dataset_options:
   dp3_ipv4_address: 172.16.91.10
   public_ipv4_public1_network: 172.16.90.0
   public_ipv4_public1_prefix: 24
-  public_ipv4_public1_dhcp_address: 172.16.90.3
   public_ipv4_public2_network: 172.16.91.0
   public_ipv4_public2_prefix: 24
-  public_ipv4_public2_dhcp_address: 172.16.91.3
   public_ipv4_address1: 172.16.90.20
   public_ipv4_address2: 172.16.90.21
   public_router_ipv4_address: 172.16.90.4

--- a/integration_test/config/itest.yml
+++ b/integration_test/config/itest.yml
@@ -24,10 +24,8 @@ dataset_options:
   dp3_ipv4_address: 172.16.91.10
   public_ipv4_public1_network: 172.16.90.0
   public_ipv4_public1_prefix: 24
-  public_ipv4_public1_dhcp_address: 172.16.90.3
   public_ipv4_public2_network: 172.16.91.0
   public_ipv4_public2_prefix: 24
-  public_ipv4_public2_dhcp_address: 172.16.91.3
   public_ipv4_address1: 172.16.90.20
   public_ipv4_address2: 172.16.90.21
   public_router_ipv4_address: 172.16.90.4

--- a/integration_test/dataset/base.yml
+++ b/integration_test/dataset/base.yml
@@ -58,25 +58,3 @@ interfaces:
     network_uuid: nw-public2
     mac_address: "02:01:00:00:00:03"
     ipv4_address: <%= dp3_ipv4_address %>
-
-  - uuid: if-dhcppub1
-    network_uuid: nw-public1
-    mac_address: "02:00:00:00:01:11"
-    ipv4_address: <%= public_ipv4_public1_dhcp_address %>
-    mode: simulated
-
-  - uuid: if-dhcppub2
-    network_uuid: nw-public2
-    mac_address: "02:00:00:00:01:22"
-    ipv4_address: <%= public_ipv4_public2_dhcp_address %>
-    mode: simulated
-
-network_services:
-
-  - uuid: ns-dhcppub1
-    interface_uuid: if-dhcppub1
-    mode: dhcp
-
-  - uuid: ns-dhcppub2
-    interface_uuid: if-dhcppub2
-    mode: dhcp


### PR DESCRIPTION
The integration test creates simulated interfaces and services for DHCP on the physical networks. These DHCP servers don't do anything and shouldn't be there.