### PR TITLE
Revert openvswitch dependency

### DIFF
--- a/deployment/packagebuild/packages.d/vnet/openvnet.spec
+++ b/deployment/packagebuild/packages.d/vnet/openvnet.spec
@@ -187,6 +187,7 @@ Summary: Virtual network agent for OpenVNet.
 BuildArch: noarch
 
 Requires: openvnet-common
+Requires: openvswitch = 2.3.1
 
 %description vna
 This package contains OpenVNet's VNA process. This is an OpenFlow controller that sends commands to Open vSwitch to implement virtual networks.

--- a/deployment/packagebuild/packages.d/vnet/openvnet.spec
+++ b/deployment/packagebuild/packages.d/vnet/openvnet.spec
@@ -187,6 +187,9 @@ Summary: Virtual network agent for OpenVNet.
 BuildArch: noarch
 
 Requires: openvnet-common
+# Open vSwitch itself is no longer required to be running on the same host as vna
+# but even when using a remote ovs, vna still depends on ovs-ofctl which is provided
+# by this package.
 Requires: openvswitch = 2.3.1
 
 %description vna

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -69,12 +69,6 @@ Though they're both required, they are not package dependencies because OpenVNet
 yum install -y mysql-server redis
 ```
 
-Install [Open vSwitch](http://www.openvswitch.org). Just like the above, this is not a package dependency because it is possible for VNA to work with a switch running remotely.
-
-```bash
-yum install -y openvswitch
-```
-
 ### Setup Open vSwitch
 
 We are going to create a bridge `br0` using Open vSwitch. Later we will attach our VMs `inst1` and `inst2` to this bridge.


### PR DESCRIPTION
I thought we could remove the ovs dependency from vna because it is now possible to use it with a remote ovs. Unfortunately I was wrong. Even when using a remote ovs, we still require `ovs-ofctl` to be installed and unfortunately that is in the same package as ovs itself. Therefore we can't drop the dependency just yet.