### PR TITLE
Fix broken segments API

### DIFF
--- a/client/ruby/lib/vnet_api_client/api_resource.rb
+++ b/client/ruby/lib/vnet_api_client/api_resource.rb
@@ -45,28 +45,52 @@ module VNetAPIClient
         end
       end
 
-      def define_standard_crud_methods
+      def define_create
         metaclass.instance_eval do
           define_method(:create) do |params = nil|
             send_request(Net::HTTP::Post, @api_suffix, params)
           end
+        end
+      end
 
+      def define_update
+        metaclass.instance_eval do
           define_method(:update) do |uuid, params = nil|
             send_request(Net::HTTP::Put, "#{@api_suffix}/#{uuid}", params)
           end
+        end
+      end
 
+      def define_delete
+        metaclass.instance_eval do
           define_method(:delete) do |uuid|
             send_request(Net::HTTP::Delete, "#{@api_suffix}/#{uuid}")
           end
+        end
+      end
 
+      def define_show
+        metaclass.instance_eval do
           define_method(:show) do |uuid|
             send_request(Net::HTTP::Get, "#{@api_suffix}/#{uuid}")
           end
+        end
+      end
 
+      def define_index
+        metaclass.instance_eval do
           define_method(:index) do
             send_request(Net::HTTP::Get, @api_suffix)
           end
         end
+      end
+
+      def define_standard_crud_methods
+        define_create
+        define_update
+        define_delete
+        define_show
+        define_index
       end
 
       def define_relation_methods(relation_name)

--- a/client/ruby/lib/vnet_api_client/api_resources.rb
+++ b/client/ruby/lib/vnet_api_client/api_resources.rb
@@ -173,7 +173,10 @@ module VNetAPIClient
   class Segment < ApiResource
     api_suffix :segments
 
-    define_standard_crud_methods
+    define_create
+    define_delete
+    define_show
+    define_index
   end
 
   class Translation < ApiResource

--- a/client/vnctl/lib/vnctl/cli/segment.rb
+++ b/client/vnctl/lib/vnctl/cli/segment.rb
@@ -5,12 +5,11 @@ module Vnctl::Cli
     namespace :segments
     api_suffix 'segments'
 
-    add_modify_shared_options {
-      option :mode, :type => :string, :desc => 'Can be either physical or virtual.'
-    }
+    option_uuid
+    option :mode, type: :string, required: true, desc: 'Can be either physical or virtual.'
+    define_add
 
-    set_required_options [:mode]
-
-    define_standard_crud_commands
+    define_show
+    define_del
   end
 end

--- a/vnet/lib/vnet/endpoints/1.0/segments.rb
+++ b/vnet/lib/vnet/endpoints/1.0/segments.rb
@@ -2,11 +2,12 @@
 
 Vnet::Endpoints::V10::VnetAPI.namespace '/segments' do
   def self.put_post_shared_params
+    param :mode, :String, in: C::Segment::MODES
   end
 
   put_post_shared_params
   param_uuid M::Segment
-  param :mode, :String, in: C::Segment::MODES
+  param_options :mode, required: true
   post do
     post_new(:Segment)
   end

--- a/vnet/lib/vnet/endpoints/1.0/segments.rb
+++ b/vnet/lib/vnet/endpoints/1.0/segments.rb
@@ -1,13 +1,8 @@
 # -*- coding: utf-8 -*-
 
 Vnet::Endpoints::V10::VnetAPI.namespace '/segments' do
-  def self.put_post_shared_params
-    param :mode, :String, in: C::Segment::MODES
-  end
-
-  put_post_shared_params
   param_uuid M::Segment
-  param_options :mode, required: true
+  param :mode, :String, in: C::Segment::MODES, required: true
   post do
     post_new(:Segment)
   end
@@ -22,11 +17,6 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/segments' do
 
   delete '/:uuid' do
     delete_by_uuid(:Segment)
-  end
-
-  put_post_shared_params
-  put '/:uuid' do
-    update_by_uuid(:Segment)
   end
 
 end

--- a/vnet/lib/vnet/node_api/segment.rb
+++ b/vnet/lib/vnet/node_api/segment.rb
@@ -15,8 +15,6 @@ module Vnet::NodeApi
 
         filter = { segment_id: model.id }
 
-        # 0010_segment
-        Segment.dispatch_deleted_where(filter, model.deleted_at)
         # 0011_assoc_interface
         InterfaceSegment.dispatch_deleted_where(filter, model.deleted_at)
       end

--- a/vnet/spec/vnet/endpoints/1.0/segments_spec.rb
+++ b/vnet/spec/vnet/endpoints/1.0/segments_spec.rb
@@ -47,12 +47,4 @@ describe "/segments" do
       it_should_return_error(400, "ArgumentError")
     end
   end
-
-  describe "PUT /:uuid" do
-    accepted_params = {
-      :mode => "physical"
-    }
-
-    include_examples "PUT /:uuid", accepted_params
-  end
 end

--- a/vnet/spec/vnet/endpoints/1.0/segments_spec.rb
+++ b/vnet/spec/vnet/endpoints/1.0/segments_spec.rb
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+require 'spec_helper'
+require 'vnet/endpoints/1.0/vnet_api'
+Dir["#{File.dirname(__FILE__)}/shared_examples/*.rb"].map {|f| require f }
+Dir["#{File.dirname(__FILE__)}/matchers/*.rb"].map {|f| require f }
+
+def app
+  Vnet::Endpoints::V10::VnetAPI
+end
+
+describe "/segments" do
+  let(:api_suffix)  { "segments" }
+  let(:fabricator)  { :segment }
+  let(:model_class) { Vnet::Models::Segment }
+
+  include_examples "GET /"
+end

--- a/vnet/spec/vnet/endpoints/1.0/segments_spec.rb
+++ b/vnet/spec/vnet/endpoints/1.0/segments_spec.rb
@@ -19,6 +19,17 @@ describe "/segments" do
   include_examples "GET /:uuid"
   include_examples "DELETE /:uuid"
 
+  describe "DELETE /:uuid event handler" do
+    let!(:object) { Fabricate(fabricator) }
+    let(:api_suffix_with_uuid) { "#{api_suffix}/#{object.canonical_uuid}" }
+
+    it "handles a single event" do
+      delete api_suffix_with_uuid
+      expect(last_response).to succeed
+      expect(MockEventHandler.handled_events.size).to eq 1
+    end
+  end
+
   describe "POST /" do
     expected_response = {
       :uuid => "seg-test",

--- a/vnet/spec/vnet/endpoints/1.0/segments_spec.rb
+++ b/vnet/spec/vnet/endpoints/1.0/segments_spec.rb
@@ -14,4 +14,6 @@ describe "/segments" do
   let(:model_class) { Vnet::Models::Segment }
 
   include_examples "GET /"
+  include_examples "GET /:uuid"
+  include_examples "DELETE /:uuid"
 end

--- a/vnet/spec/vnet/endpoints/1.0/segments_spec.rb
+++ b/vnet/spec/vnet/endpoints/1.0/segments_spec.rb
@@ -18,4 +18,22 @@ describe "/segments" do
   include_examples "GET /"
   include_examples "GET /:uuid"
   include_examples "DELETE /:uuid"
+
+  describe "POST /" do
+    expected_response = {
+      :uuid => "seg-test",
+      :mode => "virtual"
+    }
+    accepted_params = expected_response
+    required_params = [:mode]
+    uuid_params = []
+
+    include_examples "POST /", accepted_params, required_params, uuid_params, expected_response
+
+    context "With a wrong value for mode" do
+      let(:request_params) { { mode: "klein soldaatje, groot soldaatje" } }
+
+      it_should_return_error(400, "ArgumentError")
+    end
+  end
 end

--- a/vnet/spec/vnet/endpoints/1.0/segments_spec.rb
+++ b/vnet/spec/vnet/endpoints/1.0/segments_spec.rb
@@ -9,6 +9,8 @@ def app
 end
 
 describe "/segments" do
+  before(:each) { use_mock_event_handler }
+
   let(:api_suffix)  { "segments" }
   let(:fabricator)  { :segment }
   let(:model_class) { Vnet::Models::Segment }

--- a/vnet/spec/vnet/endpoints/1.0/segments_spec.rb
+++ b/vnet/spec/vnet/endpoints/1.0/segments_spec.rb
@@ -36,4 +36,12 @@ describe "/segments" do
       it_should_return_error(400, "ArgumentError")
     end
   end
+
+  describe "PUT /:uuid" do
+    accepted_params = {
+      :mode => "physical"
+    }
+
+    include_examples "PUT /:uuid", accepted_params
+  end
 end

--- a/vnet/spec/vnet/endpoints/1.0/shared_examples/delete.rb
+++ b/vnet/spec/vnet/endpoints/1.0/shared_examples/delete.rb
@@ -12,10 +12,11 @@ shared_examples "DELETE /:uuid" do
       let!(:object) { Fabricate(fabricator) }
       let(:api_suffix_with_uuid) { "#{api_suffix}/#{object.canonical_uuid}" }
 
-      it "should delete one database entry" do
+      it "should logically delete one database entry" do
         expect(last_response).to succeed.with_body([object.canonical_uuid])
 
         expect(model_class[object.canonical_uuid]).to eq(nil)
+        expect(model_class.with_deleted.where(uuid: object.uuid)).not_to eq(nil)
       end
     end
   end


### PR DESCRIPTION
A while ago it was reported to me that the segments API 100% crashes on deletion. I wonder how an issue of that magnitude could ever make it through the unit tests and the answer is there were no unit tests. \*facepalm* 

So in this PR I:

* Wrote those very needed unit tests
* Fixed that guaranteed crash on deletion
* ~~Fixed another major issue where updating a segment did nothing at all~~
* Removed all segment update code from webapi and clients (which was in place before this PR). I was told updating segments should not be allowed.
* Fixed another issue where `mode` was not required in the webapi. Omitting it would set it to an empty string in the database. Wonder how VNA would have dealt with that.

Remember to test your code, people.