### PR TITLE
Filter api unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * `Changed` It is no longer possibly to directly modify an IP lease through the WebAPI. In order to preserve network state history, IP leases need to be deleted and recreated.
 
+* `Changed` the static filter webapi parameters to be more inline with the current functionality.
+
 * `Changed` We now use the [PIO](https://github.com/trema/pio) library to manage MAC addresses.
 
 * `Changed` Refactored IP/MAC leases and wrote a bunch more unit tests for them.

--- a/client/ruby/lib/vnet_api_client/api_resources.rb
+++ b/client/ruby/lib/vnet_api_client/api_resources.rb
@@ -203,18 +203,18 @@ module VNetAPIClient
 
     define_standard_crud_methods
 
-    def self.add_filter_static(filter_uuid, params = nil)
+    def self.add_static(filter_uuid, params = nil)
       send_request(Net::HTTP::Post,
                    "#{@api_suffix}/#{filter_uuid}/static",
                    params)
     end
 
-    def self.remove_filter_static(filter_uuid, params = nil)
+    def self.remove_static(filter_uuid, params = nil)
       send_request(Net::HTTP::Delete,
                    "#{@api_suffix}/#{filter_uuid}/static",
                    params)
     end
-    def self.show_filter_static_by_uuid(filter_uuid, params = nil)
+    def self.show_static(filter_uuid, params = nil)
       send_request(Net::HTTP::Get,
                    "#{@api_suffix}/#{filter_uuid}/static",
                    params)

--- a/client/ruby/lib/vnet_api_client/api_resources.rb
+++ b/client/ruby/lib/vnet_api_client/api_resources.rb
@@ -214,14 +214,9 @@ module VNetAPIClient
                    "#{@api_suffix}/#{filter_uuid}/static",
                    params)
     end
-    def self.show_filter_static(params = nil)
-      send_request(Net::HTTP::Get,
-                   "#{@api_suffix}/static/",
-                   params)
-    end
     def self.show_filter_static_by_uuid(filter_uuid, params = nil)
       send_request(Net::HTTP::Get,
-                   "#{@api_suffix}/static/#{filter_uuid}",
+                   "#{@api_suffix}/#{filter_uuid}/static",
                    params)
     end
   end

--- a/client/vnctl/lib/vnctl/cli/base.rb
+++ b/client/vnctl/lib/vnctl/cli/base.rb
@@ -289,8 +289,8 @@ module Vnctl::Cli
           }
 
           desc "show #{mode_type} #{base_uuid.upcase}_UUID",  "Shows all #{mode_type}s."
-          define_method("show") { | uuid = nil |
-            puts Vnctl.webapi.get("#{suffix}/#{mode_type}/#{uuid}")
+          define_method("show") { | uuid |
+            puts Vnctl.webapi.get("#{suffix}/#{uuid}/#{mode_type}")
           }
         end
 

--- a/client/vnctl/lib/vnctl/cli/filter.rb
+++ b/client/vnctl/lib/vnctl/cli/filter.rb
@@ -3,14 +3,18 @@ module Vnctl::Cli
     namespace :filters
     api_suffix "filters"
 
+    add_shared_options {
+      option :interface_uuid, :type => :string, :required => true,
+        :desc => "This interface uuid that will use this filter."
+      option :mode, :type => :string, :required => true,
+        :desc => "The mode for this translation."
+    }
+
     add_modify_shared_options {
-      option :interface_uuid, :type => :string, :desc => "This interface uuid that will use this filter."
-      option :mode, :type => :string, :desc => "The mode for this translation."
+      #TODO remove interface_uuid and mode from update
       option :egress_passthrough, :type => :boolean, :desc => "Flag that sets if outgoing data will pass through or be dropped."
       option :ingress_passthrough, :type => :boolean, :desc => "Flag that sets if incoming data will pass through or be dropped."
     }
-
-    set_required_options [:interface_uuid, :mode]
 
     define_standard_crud_commands
 

--- a/client/vnctl/lib/vnctl/cli/filter.rb
+++ b/client/vnctl/lib/vnctl/cli/filter.rb
@@ -11,7 +11,6 @@ module Vnctl::Cli
     }
 
     add_modify_shared_options {
-      #TODO remove interface_uuid and mode from update
       option :egress_passthrough, :type => :boolean, :desc => "Flag that sets if outgoing data will pass through or be dropped."
       option :ingress_passthrough, :type => :boolean, :desc => "Flag that sets if incoming data will pass through or be dropped."
     }
@@ -27,15 +26,6 @@ module Vnctl::Cli
         :desc => "This is the port number the filter will listen on."
       mode.option :passthrough, :type => :boolean,
         :desc => "Flag that controls where the static should pass or drop data for specified rule."
-
-      mode.option :ipv4_src_address, :type => :string,
-        :desc => "This is the address the filter will apply for incoming traffic."
-      mode.option :ipv4_dst_address, :type => :string,
-        :desc => "This is the address the filter will apply for outgoing traffic."
-      mode.option :port_src, :type => :string,
-        :desc => "This is the port which the rule will apply to for incoming traffic."
-      mode.option :port_dst, :type => :string,
-        :desc => "This is the port which the rule will apply to for outgoing traffic."
     end
   end
 end

--- a/client/vnctl/lib/vnctl/cli/filter.rb
+++ b/client/vnctl/lib/vnctl/cli/filter.rb
@@ -24,7 +24,7 @@ module Vnctl::Cli
         :desc => "This is the protocol which the filter will listen on. [tcp, udp, icmp, arp]"
       mode.option :port_number, :type => :string,
         :desc => "This is the port number the filter will listen on. Required for tcp and udp."
-      mode.option :passthrough, :type => :boolean, :required => true,
+      mode.option :passthrough, :type => :boolean, :default => false,
         :desc => "Flag that controls where the static should pass or drop data for specified rule."
     end
   end

--- a/client/vnctl/lib/vnctl/cli/filter.rb
+++ b/client/vnctl/lib/vnctl/cli/filter.rb
@@ -22,7 +22,7 @@ module Vnctl::Cli
       mode.option :port_number, :type => :string,
         :desc => "This is the port number the filter will listen on."
       mode.option :passthrough, :type => :boolean,
-        :desc => "Flag that controlls where the static should pass or drop data for specified rule."
+        :desc => "Flag that controls where the static should pass or drop data for specified rule."
 
       mode.option :ipv4_src_address, :type => :string,
         :desc => "This is the address the filter will apply for incoming traffic."

--- a/client/vnctl/lib/vnctl/cli/filter.rb
+++ b/client/vnctl/lib/vnctl/cli/filter.rb
@@ -19,12 +19,12 @@ module Vnctl::Cli
 
     define_mode_relation(:static) do | mode |
       mode.option :ipv4_address, :type => :string,
-        :desc => "This is the ipv4 address the filter will be applied on."
+        :desc => "This is the ipv4 address the filter will be applied on. Required for tcp, udp and icmp."
       mode.option :protocol, :type => :string, :required => true,
-        :desc => "This is the protocol which the filter will listen on."
+        :desc => "This is the protocol which the filter will listen on. [tcp, udp, icmp, arp]"
       mode.option :port_number, :type => :string,
-        :desc => "This is the port number the filter will listen on."
-      mode.option :passthrough, :type => :boolean,
+        :desc => "This is the port number the filter will listen on. Required for tcp and udp."
+      mode.option :passthrough, :type => :boolean, :required => true,
         :desc => "Flag that controls where the static should pass or drop data for specified rule."
     end
   end

--- a/integration_test/dataset/filter.yml
+++ b/integration_test/dataset/filter.yml
@@ -143,7 +143,6 @@ filter_static:
     passthrough: true
   - filter_uuid : fil-test1
     protocol: "arp"
-    ipv4_address: "0.0.0.0/0"
     passthrough: true
 
   - filter_uuid: fil-test3
@@ -172,7 +171,6 @@ filter_static:
     passthrough: true
   - filter_uuid : fil-test3
     protocol: "arp"
-    ipv4_address: "0.0.0.0/0"
     passthrough: true
 
 
@@ -187,7 +185,6 @@ filter_static:
     passthrough: true
   - filter_uuid : fil-test4
     protocol: "arp"
-    ipv4_address: "0.0.0.0/0"
     passthrough: true
   - filter_uuid: fil-test4
     protocol: "udp"

--- a/integration_test/lib/vnspec/spec/filter_spec.rb
+++ b/integration_test/lib/vnspec/spec/filter_spec.rb
@@ -70,7 +70,7 @@ describe "filters" do
     it "vm3 accepts incoming packages on udp 10.101.0.13 port 1344" do
       expect(vm4).to be_able_to_send_udp(vm3, 1344)
     end
-    it "vm3 blocks non filterd sources packages on udp" do
+    it "vm3 blocks non filtered sources packages on udp" do
       expect(vm4).not_to be_able_to_send_udp(vm3, 1345)
       expect(vm1).not_to be_able_to_send_udp(vm3, 1344)
     end

--- a/vnet/lib/vnet.rb
+++ b/vnet/lib/vnet.rb
@@ -48,6 +48,8 @@ module Vnet
 
   module Constants
     autoload :ActivePort, 'vnet/constants/active_port'
+    autoload :Filter, 'vnet/constants/filter'
+    autoload :FilterStatic, 'vnet/constants/filter_static'
     autoload :Interface, 'vnet/constants/interface'
     autoload :LeasePolicy, 'vnet/constants/lease_policy'
     autoload :MacAddressPrefix, 'vnet/constants/mac_address_prefix'
@@ -59,7 +61,6 @@ module Vnet
     autoload :Translation, 'vnet/constants/translation'
     autoload :Topology, 'vnet/constants/topology'
     autoload :VnetAPI, 'vnet/constants/vnet_api'
-    autoload :Filter, 'vnet/constants/filter'
   end
 
   module Core

--- a/vnet/lib/vnet/constants/filter_static.rb
+++ b/vnet/lib/vnet/constants/filter_static.rb
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+module Vnet::Constants::FilterStatic
+  PROTOCOL_TCP  = 'tcp'
+  PROTOCOL_UDP  = 'udp'
+  PROTOCOL_ICMP = 'icmp'
+  PROTOCOL_ARP  = 'arp'
+  PROTOCOL_ALL  = 'all'
+
+  PROTOCOLS = [
+    PROTOCOL_TCP,
+    PROTOCOL_UDP,
+    PROTOCOL_ICMP,
+    PROTOCOL_ARP,
+    PROTOCOL_ALL
+  ]
+end

--- a/vnet/lib/vnet/endpoints/1.0/filters.rb
+++ b/vnet/lib/vnet/endpoints/1.0/filters.rb
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
 
-#TODO: Write some FREAKING tests for this
 Vnet::Endpoints::V10::VnetAPI.namespace '/filters' do
   CF = C::Filter
 
   def self.put_post_shared_params
-    param_uuid M::Interface, :interface_uuid
-    param :mode, :String, in: CF::MODES
     param :egress_passthrough, :Boolean
     param :ingress_passthrough, :Boolean
   end
@@ -14,7 +11,7 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/filters' do
   put_post_shared_params
   param_uuid M::Filter
   param_uuid M::Interface, :interface_uuid, required: true
-  param_options :mode, required: true
+  param :mode, :String, in: CF::MODES, required: true
   post do
     uuid_to_id(M::Interface, "interface_uuid", "interface_id")
 

--- a/vnet/lib/vnet/endpoints/1.0/filters.rb
+++ b/vnet/lib/vnet/endpoints/1.0/filters.rb
@@ -38,17 +38,13 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/filters' do
   end
 
   def self.static_shared_params
-    param :ipv4_address, :String, transform: PARSE_IPV4_ADDRESS
-    param :port_number, :Integer, in: 0..65536
-    param :protocol, :String
-    param :passthrough, :Boolean
+    param :ipv4_address, :String, transform: PARSE_IPV4_ADDRESS, required: true
+    param :port_number, :Integer, in: 0..65536, required: true
+    param :protocol, :String, required: true
+    param :passthrough, :Boolean, required: true
   end
 
   static_shared_params
-  param_options :ipv4_address, required: true
-  param_options :port_number, required: true
-  param_options :protocol, required: true
-  param_options :passthrough, required: true
   post '/:uuid/static' do
 
     filter = check_syntax_and_pop_uuid(M::Filter)
@@ -61,7 +57,7 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/filters' do
       filter_id: filter.id,
       ipv4_src_address: params["ipv4_address"].to_i,
       ipv4_src_prefix: params["ipv4_address"].prefix,
-      ipv4_dst_address: "0",
+      ipv4_dst_address: 0,
       ipv4_dst_prefix: 0,
       port_src: params["port_number"],
       port_dst: params["port_number"],
@@ -73,7 +69,6 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/filters' do
   end
 
   static_shared_params
-  param :id, :Integer
   delete '/:uuid/static' do
     filter = check_syntax_and_pop_uuid(M::Filter)
 
@@ -83,8 +78,17 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/filters' do
 
     remove_system_parameters
 
-    filter_params = params.inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
-    filter_params[:filter_id] = filter.id
+    filter_params = {
+      filter_id: filter.id,
+      ipv4_src_address: params["ipv4_address"].to_i,
+      ipv4_src_prefix: params["ipv4_address"].prefix.to_i,
+      ipv4_dst_address: 0,
+      ipv4_dst_prefix: 0,
+      port_src: params["port_number"],
+      port_dst: params["port_number"],
+      protocol: params["protocol"],
+      passthrough: params["passthrough"]
+    }
 
     s = M::FilterStatic.batch[filter_params].commit
 

--- a/vnet/lib/vnet/endpoints/1.0/filters.rb
+++ b/vnet/lib/vnet/endpoints/1.0/filters.rb
@@ -15,7 +15,6 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/filters' do
   post do
     uuid_to_id(M::Interface, "interface_uuid", "interface_id")
 
-    #TODO: remove interface_id from response
     post_new :Filter
   end
 

--- a/vnet/lib/vnet/endpoints/1.0/filters.rb
+++ b/vnet/lib/vnet/endpoints/1.0/filters.rb
@@ -2,6 +2,7 @@
 
 Vnet::Endpoints::V10::VnetAPI.namespace '/filters' do
   CF = C::Filter
+  CFS = C::FilterStatic
 
   def self.put_post_shared_params
     param :egress_passthrough, :Boolean
@@ -40,7 +41,7 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/filters' do
   def self.static_shared_params
     param :ipv4_address, :String, transform: PARSE_IPV4_ADDRESS
     param :port_number, :Integer, in: 0..65536
-    param :protocol, :String, in: ['tcp', 'udp', 'icmp', 'arp', 'all'], required: true
+    param :protocol, :String, in: CFS::PROTOCOLS, required: true
     param :passthrough, :Boolean, required: true
   end
 

--- a/vnet/lib/vnet/endpoints/1.0/filters.rb
+++ b/vnet/lib/vnet/endpoints/1.0/filters.rb
@@ -58,7 +58,7 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/filters' do
       ipv4_src_prefix = params["ipv4_address"].prefix.to_i
       port_number = nil
     when "arp", "all"
-      ipv4_address = 0
+      ipv4_src_address = 0
       ipv4_src_prefix = 0
       port_number = nil
     end

--- a/vnet/lib/vnet/endpoints/1.0/filters.rb
+++ b/vnet/lib/vnet/endpoints/1.0/filters.rb
@@ -114,7 +114,7 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/filters' do
     get_all(:FilterStatic)
   end
 
-  get '/static/:uuid' do
+  get '/:uuid/static' do
     show_relations(:Filter, :filter_statics)
   end
 end

--- a/vnet/lib/vnet/endpoints/1.0/filters.rb
+++ b/vnet/lib/vnet/endpoints/1.0/filters.rb
@@ -39,7 +39,7 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/filters' do
   end
 
   def self.static_shared_params
-    param :ipv4_address, :String, transform: PARSE_IPV4_ADDRESS, required: true
+    param :ipv4_address, :String, transform: PARSE_IPV4_ADDRESS
     param :port_number, :Integer, in: 0..65536
     param :protocol, :String, in: ['tcp', 'udp', 'icmp', 'arp', 'all'], required: true
     param :passthrough, :Boolean, required: true
@@ -49,11 +49,14 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/filters' do
     case params["protocol"]
     when "tcp", "udp"
       raise E::MissingArgument, 'port_number' if params["port_number"].nil?
+      raise E::MissingArgument, 'ipv4_address' if params["ipv4_address"].nil?
 
       ipv4_src_address = params["ipv4_address"].to_i
       ipv4_src_prefix = params["ipv4_address"].prefix.to_i
       port_number = params["port_number"]
     when "icmp"
+      raise E::MissingArgument, 'ipv4_address' if params["ipv4_address"].nil?
+
       ipv4_src_address = params["ipv4_address"].to_i
       ipv4_src_prefix = params["ipv4_address"].prefix.to_i
       port_number = nil
@@ -73,7 +76,7 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/filters' do
       ipv4_src_prefix: ipv4_src_prefix,
       ipv4_dst_address: 0,
       ipv4_dst_prefix: 0,
-      port_src: port_number,
+      port_src: port_number && 0,
       port_dst: port_number,
       protocol: params["protocol"],
       passthrough: params["passthrough"]

--- a/vnet/lib/vnet/endpoints/1.0/filters.rb
+++ b/vnet/lib/vnet/endpoints/1.0/filters.rb
@@ -76,7 +76,7 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/filters' do
       ipv4_src_prefix: ipv4_src_prefix,
       ipv4_dst_address: 0,
       ipv4_dst_prefix: 0,
-      port_src: port_number && 0,
+      port_src: port_number,
       port_dst: port_number,
       protocol: params["protocol"],
       passthrough: params["passthrough"]

--- a/vnet/lib/vnet/endpoints/1.0/filters.rb
+++ b/vnet/lib/vnet/endpoints/1.0/filters.rb
@@ -34,7 +34,7 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/filters' do
   put '/:uuid' do
     uuid_to_id(M::Interface, "interface_uuid", "interface_id") if params["interface_uuid"]
 
-    update_by_uuid(:Filter)
+    update_by_uuid2(:Filter)
   end
 
   def self.static_shared_params

--- a/vnet/lib/vnet/endpoints/1.0/filters.rb
+++ b/vnet/lib/vnet/endpoints/1.0/filters.rb
@@ -110,10 +110,6 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/filters' do
 
   end
 
-  get '/static/' do
-    get_all(:FilterStatic)
-  end
-
   get '/:uuid/static' do
     show_relations(:Filter, :filter_statics)
   end

--- a/vnet/lib/vnet/endpoints/1.0/filters.rb
+++ b/vnet/lib/vnet/endpoints/1.0/filters.rb
@@ -40,16 +40,15 @@ Vnet::Endpoints::V10::VnetAPI.namespace '/filters' do
   def self.static_shared_params
     param :ipv4_address, :String, transform: PARSE_IPV4_ADDRESS
     param :port_number, :Integer, in: 0..65536
-
-    param :ipv4_src_address, :String, transform: PARSE_IPV4_ADDRESS
-    param :ipv4_dst_address, :String, transform: PARSE_IPV4_ADDRESS
-    param :port_src, :Integer, in: 0..65536
-    param :port_dst, :Integer, in: 0..65536
     param :protocol, :String
     param :passthrough, :Boolean
   end
 
   static_shared_params
+  param_options :ipv4_address, required: true
+  param_options :port_number, required: true
+  param_options :protocol, required: true
+  param_options :passthrough, required: true
   post '/:uuid/static' do
 
     filter = check_syntax_and_pop_uuid(M::Filter)

--- a/vnet/lib/vnet/endpoints/1.0/responses/filter.rb
+++ b/vnet/lib/vnet/endpoints/1.0/responses/filter.rb
@@ -4,9 +4,11 @@ module Vnet::Endpoints::V10::Responses
   class Filter < Vnet::Endpoints::CollectionResponseGenerator
     def self.generate(object)
       argument_type_check(object,Vnet::ModelWrappers::Filter)
+
       object.to_hash.tap do |res|
         interface = object.batch.interface.commit
         res[:interface_uuid] = interface.uuid if interface
+        res.delete(:interface_id)
       end
     end
 

--- a/vnet/lib/vnet/endpoints/1.0/responses/filter_static.rb
+++ b/vnet/lib/vnet/endpoints/1.0/responses/filter_static.rb
@@ -7,6 +7,7 @@ module Vnet::Endpoints::V10::Responses
 
       res = {
         ipv4_address: object.batch.ipv4_src_address_s.commit,
+        ipv4_prefix: object.ipv4_src_prefix,
         port_number: object.port_dst,
         protocol: object.protocol,
         passthrough: object.passthrough

--- a/vnet/lib/vnet/endpoints/1.0/responses/filter_static.rb
+++ b/vnet/lib/vnet/endpoints/1.0/responses/filter_static.rb
@@ -4,19 +4,12 @@ module Vnet::Endpoints::V10::Responses
   class FilterStatic < Vnet::Endpoints::CollectionResponseGenerator
     def self.generate(object)
       argument_type_check(object,Vnet::ModelWrappers::FilterStatic)
-      object.to_hash.tap { |res|
-        # Separation between source port and destination port is implemented
-        # in the model but the code to handle it isn't quite there yet. Hide the
-        # model in the API response for now.
-        res[:port_number] = res[:port_src]
-        res.delete(:port_src)
-        res.delete(:port_dst)
 
-        # Same as the above for ipv4 address.
-        res[:ipv4_address] = object.batch.ipv4_src_address_s.commit
-        res.delete(:ipv4_src_address)
-        res.delete(:ipv4_dst_address)
-        res.delete(:ipv4_dst_prefix)
+      res = {
+        ipv4_address: object.batch.ipv4_src_address_s.commit,
+        port_number: object.port_dst,
+        protocol: object.protocol,
+        passthrough: object.passthrough
       }
     end
   end

--- a/vnet/lib/vnet/endpoints/1.0/responses/filter_static.rb
+++ b/vnet/lib/vnet/endpoints/1.0/responses/filter_static.rb
@@ -5,10 +5,18 @@ module Vnet::Endpoints::V10::Responses
     def self.generate(object)
       argument_type_check(object,Vnet::ModelWrappers::FilterStatic)
       object.to_hash.tap { |res|
-#        interface = object.batch.interface.commit
-#        res[:interface_uuid] = interface.uuid if interface
-        res[:ipv4_dst_address] = object.batch.ipv4_dst_address_s.commit
-        res[:ipv4_src_address] = object.batch.ipv4_src_address_s.commit
+        # Separation between source port and destination port is implemented
+        # in the model but the code to handle it isn't quite there yet. Hide the
+        # model in the API response for now.
+        res[:port_number] = res[:port_src]
+        res.delete(:port_src)
+        res.delete(:port_dst)
+
+        # Same as the above for ipv4 address.
+        res[:ipv4_address] = object.batch.ipv4_src_address_s.commit
+        res.delete(:ipv4_src_address)
+        res.delete(:ipv4_dst_address)
+        res.delete(:ipv4_dst_prefix)
       }
     end
   end

--- a/vnet/lib/vnet/models/filter_static.rb
+++ b/vnet/lib/vnet/models/filter_static.rb
@@ -19,23 +19,23 @@ module Vnet::Models
     end
 
     def validate
-      errors.add(:ipv4_src_prefix, "prefix out of range") if !(0..32).member?(self.ipv4_src_prefix)
-      errors.add(:ipv4_dst_prefix, "prefix out of range") if !(0..32).member?(self.ipv4_dst_prefix)
-      errors.add(:protocol, "unknown protocol type #{self.protocol}") if !protocol_included(["tcp", "udp", "icmp", "arp", "all"])
+      errors.add(:ipv4_src_prefix, "src prefix out of range: '#{self.ipv4_src_prefix}'") if !(0..32).member?(self.ipv4_src_prefix)
+      errors.add(:ipv4_dst_prefix, "dst prefix out of range: '#{self.ipv4_dst_prefix}'") if !(0..32).member?(self.ipv4_dst_prefix)
+      errors.add(:protocol, "unknown protocol: '#{self.protocol}'") if !protocol_included(["tcp", "udp", "icmp", "arp", "all"])
 
       if protocol_included(["tcp", "udp"])
-        errors.add(:port_src, "port not in valid range") if !(0..0xffff).member?(self.port_src)
-        errors.add(:port_dst, "port not in valid range") if !(0..0xffff).member?(self.port_dst)
+        errors.add(:port_src, "src port not in valid range: '#{self.port_src}'") if !(0..0xffff).member?(self.port_src)
+        errors.add(:port_dst, "dst port not in valid range: '#{self.port_dst}'") if !(0..0xffff).member?(self.port_dst)
       elsif protocol_included(["arp", "icmp", "all"])
-        errors.add(:port_src, "port needs to be nil") if !self.port_src.nil?
-        errors.add(:port_dst, "port needs to be nil") if !self.port_dst.nil?
+        errors.add(:port_src, "src port needs to be nil") if !self.port_src.nil?
+        errors.add(:port_dst, "dst port needs to be nil") if !self.port_dst.nil?
       elsif protocol_included(["arp", "all"])
-        errors.add(:ipv4_src_address, "ip address needs to be 0") if (self.ipv4_src_address > 0) # needs inspection
-        errors.add(:ipv4_dst_address, "ip address needs to be 0") if (self.ipv4_dst_address > 0) # needs inspection
+        errors.add(:ipv4_src_address, "src IP address needs to be 0") if (self.ipv4_src_address > 0) # needs inspection
+        errors.add(:ipv4_dst_address, "dst IP address needs to be 0") if (self.ipv4_dst_address > 0) # needs inspection
       end
 
-      errors.add(:ipv4_dst_prefix, "prefix needs to be 0") if ipv4_dst_prefix != 0 && self.ipv4_dst_address == 0
-      errors.add(:ipv4_src_prefix, "prefix needs to be 0") if ipv4_src_prefix != 0 && self.ipv4_src_address == 0
+      errors.add(:ipv4_dst_prefix, "dst prefix needs to be 0") if ipv4_dst_prefix != 0 && self.ipv4_dst_address == 0
+      errors.add(:ipv4_src_prefix, "src prefix needs to be 0") if ipv4_src_prefix != 0 && self.ipv4_src_address == 0
     end
 
     private

--- a/vnet/lib/vnet/models/filter_static.rb
+++ b/vnet/lib/vnet/models/filter_static.rb
@@ -19,23 +19,23 @@ module Vnet::Models
     end
 
     def validate
-      errors.add(:ipv4_src_prefix, "src prefix out of range: '#{self.ipv4_src_prefix}'") if !(0..32).member?(self.ipv4_src_prefix)
-      errors.add(:ipv4_dst_prefix, "dst prefix out of range: '#{self.ipv4_dst_prefix}'") if !(0..32).member?(self.ipv4_dst_prefix)
+      errors.add(:ipv4_src_prefix, "out of range: '#{self.ipv4_src_prefix}'") if !(0..32).member?(self.ipv4_src_prefix)
+      errors.add(:ipv4_dst_prefix, "out of range: '#{self.ipv4_dst_prefix}'") if !(0..32).member?(self.ipv4_dst_prefix)
       errors.add(:protocol, "unknown protocol: '#{self.protocol}'") if !protocol_included(["tcp", "udp", "icmp", "arp", "all"])
 
       if protocol_included(["tcp", "udp"])
-        errors.add(:port_src, "src port not in valid range: '#{self.port_src}'") if !(0..0xffff).member?(self.port_src)
-        errors.add(:port_dst, "dst port not in valid range: '#{self.port_dst}'") if !(0..0xffff).member?(self.port_dst)
+        errors.add(:port_src, "not in valid range: '#{self.port_src}'") if !(0..0xffff).member?(self.port_src)
+        errors.add(:port_dst, "not in valid range: '#{self.port_dst}'") if !(0..0xffff).member?(self.port_dst)
       elsif protocol_included(["arp", "icmp", "all"])
-        errors.add(:port_src, "src port needs to be nil") if !self.port_src.nil?
-        errors.add(:port_dst, "dst port needs to be nil") if !self.port_dst.nil?
+        errors.add(:port_src, "needs to be nil") if !self.port_src.nil?
+        errors.add(:port_dst, "needs to be nil") if !self.port_dst.nil?
       elsif protocol_included(["arp", "all"])
-        errors.add(:ipv4_src_address, "src IP address needs to be 0") if (self.ipv4_src_address > 0) # needs inspection
-        errors.add(:ipv4_dst_address, "dst IP address needs to be 0") if (self.ipv4_dst_address > 0) # needs inspection
+        errors.add(:ipv4_src_address, "address needs to be 0") if (self.ipv4_src_address > 0) # needs inspection
+        errors.add(:ipv4_dst_address, "address needs to be 0") if (self.ipv4_dst_address > 0) # needs inspection
       end
 
-      errors.add(:ipv4_dst_prefix, "dst prefix needs to be 0") if ipv4_dst_prefix != 0 && self.ipv4_dst_address == 0
-      errors.add(:ipv4_src_prefix, "src prefix needs to be 0") if ipv4_src_prefix != 0 && self.ipv4_src_address == 0
+      errors.add(:ipv4_dst_prefix, "needs to be 0") if ipv4_dst_prefix != 0 && self.ipv4_dst_address == 0
+      errors.add(:ipv4_src_prefix, "needs to be 0") if ipv4_src_prefix != 0 && self.ipv4_src_address == 0
     end
 
     private

--- a/vnet/lib/vnet/node_api/filter.rb
+++ b/vnet/lib/vnet/node_api/filter.rb
@@ -3,23 +3,11 @@
 module Vnet::NodeApi
 
   class Filter < EventBase
-    class << self
-      def update(uuid, options)
-        options.each { |param|
-          return unless param.first == "ingress_passthrough" || param.first == "egress_passthrough"
-        }
+    valid_update_fields [:ingress_passthrough, :egress_passthrough]
 
-        filter = transaction {
-          model_class[uuid].tap do |model|
-            model.update(options)
-          end
-        }.tap { |filter|
-          dispatch_event(FILTER_UPDATED,
-                         id: filter.id,
-                         ingress_passthrough: filter.ingress_passthrough,
-                         egress_passthrough: filter.egress_passthrough
-                        )
-        }
+    class << self
+      def dispatch_updated_item_events(model, old_values)
+        dispatch_event(FILTER_UPDATED, get_changed_hash(model, old_values.keys))
       end
 
       private

--- a/vnet/spec/client/ruby/ruby_client_spec.rb
+++ b/vnet/spec/client/ruby/ruby_client_spec.rb
@@ -193,14 +193,12 @@ describe VNetAPIClient do
   end
 
   describe VNetAPIClient::Filter do
-    include_examples 'test_method', :add_filter_static,
+    include_examples 'test_method', :add_static,
                      'POST  /filters/:uuid/static'
-    include_examples 'test_method', :remove_filter_static,
+    include_examples 'test_method', :remove_static,
                      'DELETE  /filters/:uuid/static'
-    include_examples 'test_method', :show_filter_static,
-                     'GET  /filters/static/'
-    include_examples 'test_method', :show_filter_static_by_uuid,
-                     'GET  /filters/static/:uuid'
+    include_examples 'test_method', :show_static,
+                     'GET  /filters/:uuid/static'
   end
   #
   # Finally we make sure that no non standard routes are left untested

--- a/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
+++ b/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
@@ -46,7 +46,7 @@ describe "/filters" do
     let!(:interface) { Fabricate(:interface) { uuid "if-test" } }
 
     accepted_params = {
-      :egress_passthrough => false,
+      :egress_passthrough => true,
       :ingress_passthrough => true,
     }
 

--- a/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
+++ b/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
@@ -34,5 +34,11 @@ describe "/filters" do
     uuid_params = [:interface_uuid]
 
     include_examples "POST /", accepted_params, required_params, uuid_params, expected_response
+
+    context "With a wrong value for mode" do
+      let(:request_params) { accepted_params.merge({ mode: "a squirrel" }) }
+
+      it_should_return_error(400, "ArgumentError")
+    end
   end
 end

--- a/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
+++ b/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
@@ -41,4 +41,17 @@ describe "/filters" do
       it_should_return_error(400, "ArgumentError")
     end
   end
+
+  describe "PUT /:uuid" do
+    let!(:interface) { Fabricate(:interface) { uuid "if-test" } }
+
+    accepted_params = {
+      :interface => "if-test",
+      :egress_passthrough => false,
+      :ingress_passthrough => true,
+      :mode => "static"
+    }
+
+    include_examples "PUT /:uuid", accepted_params
+  end
 end

--- a/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
+++ b/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
@@ -154,7 +154,7 @@ describe "/filters" do
             ipv4_src_prefix: 32,
             ipv4_dst_address: 0,
             ipv4_dst_prefix: 0,
-            port_src: 0,
+            port_src: 24056,
             port_dst: 24056,
             protocol: protocol,
             passthrough: true}

--- a/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
+++ b/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
@@ -80,7 +80,7 @@ describe "/filters" do
         ipv4_src_prefix: 32,
         ipv4_dst_address: 0,
         ipv4_dst_prefix: 0,
-        port_src: 24056,
+        port_src: 0,
         port_dst: 24056,
         protocol: "tcp",
         passthrough: true}

--- a/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
+++ b/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
@@ -52,4 +52,25 @@ describe "/filters" do
 
     include_examples "PUT /:uuid", accepted_params
   end
+
+  describe "/:uuid/static" do
+    let!(:filter) { Fabricate(:filter, mode: "static") }
+
+    let(:api_suffix) { "filters/#{filter.canonical_uuid}/static" }
+    let(:fabricator) { :filter_static}
+    let(:model_class) { Vnet::Models::FilterStatic }
+
+    accepted_params = {
+      ipv4_address: "192.168.100.150",
+      port_number: 24056,
+      protocol: "tcp",
+      passthrough: true
+    }
+    required_params = []
+    uuid_params = []
+
+    describe "POST" do
+      include_examples "POST /", accepted_params, required_params, uuid_params
+    end
+  end
 end

--- a/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
+++ b/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
@@ -18,4 +18,21 @@ describe "/filters" do
   include_examples "GET /"
   include_examples "GET /:uuid"
   include_examples "DELETE /:uuid"
+
+  describe "POST /" do
+    let!(:interface) { Fabricate(:interface) { uuid "if-filtest" } }
+
+    expected_response = {
+      :uuid => "fil-test",
+      :interface_uuid => "if-filtest",
+      :egress_passthrough => true,
+      :ingress_passthrough => true,
+      :mode => "static"
+    }
+    accepted_params = expected_response
+    required_params = [:interface_uuid, :mode]
+    uuid_params = [:interface_uuid]
+
+    include_examples "POST /", accepted_params, required_params, uuid_params, expected_response
+  end
 end

--- a/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
+++ b/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
@@ -69,8 +69,27 @@ describe "/filters" do
     required_params = [:ipv4_address, :protocol, :port_number, :passthrough]
     uuid_params = []
 
-    describe "POST" do
+    describe "POST (tcp)" do
       include_examples "POST /", accepted_params, required_params, uuid_params
+    end
+
+    describe "POST (udp)" do
+      include_examples "POST /", accepted_params.merge(protocol: 'udp'),
+                                 required_params, uuid_params
+    end
+
+    describe "POST (icmp)" do
+      include_examples "POST /", accepted_params.merge(protocol: 'icmp', port_number: nil),
+                                 [:ipv4_address, :protocol, :passthrough],
+                                 uuid_params
+    end
+
+    describe "POST (arp)" do
+      accepted = {
+        protocol: 'arp',
+        passthrough: true
+      }
+      include_examples "POST /", accepted, [:protocol, :passthrough], uuid_params
     end
 
     describe "DELETE" do

--- a/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
+++ b/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
@@ -94,7 +94,7 @@ describe "/filters" do
       context "with a different filter id" do
         let(:entries) { 3 }
         let(:api_suffix) {
-            new_filter = Fabricate(:filter, mode: "static")
+          new_filter = Fabricate(:filter, mode: "static")
           "filters/#{new_filter.canonical_uuid}/static"
         }
 

--- a/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
+++ b/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+require 'spec_helper'
+require 'vnet/endpoints/1.0/vnet_api'
+Dir["#{File.dirname(__FILE__)}/shared_examples/*.rb"].map {|f| require f }
+Dir["#{File.dirname(__FILE__)}/matchers/*.rb"].map {|f| require f }
+
+def app
+  Vnet::Endpoints::V10::VnetAPI
+end
+
+describe "/filters" do
+  before(:each) { use_mock_event_handler }
+
+  let(:api_suffix)  { "filters" }
+  let(:fabricator)  { :filter }
+  let(:model_class) { Vnet::Models::Filter }
+
+  include_examples "GET /"
+  include_examples "GET /:uuid"
+  include_examples "DELETE /:uuid"
+end

--- a/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
+++ b/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
@@ -66,7 +66,7 @@ describe "/filters" do
       protocol: "tcp",
       passthrough: true
     }
-    required_params = []
+    required_params = [:ipv4_address, :protocol, :port_number, :passthrough]
     uuid_params = []
 
     describe "POST" do

--- a/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
+++ b/vnet/spec/vnet/endpoints/1.0/filters_spec.rb
@@ -46,10 +46,8 @@ describe "/filters" do
     let!(:interface) { Fabricate(:interface) { uuid "if-test" } }
 
     accepted_params = {
-      :interface => "if-test",
       :egress_passthrough => false,
       :ingress_passthrough => true,
-      :mode => "static"
     }
 
     include_examples "PUT /:uuid", accepted_params


### PR DESCRIPTION
While working on https://github.com/axsh/openvnet/pull/512 I noticed that the filters API wasn't tested either. The `PUT` route was crashing on every request and the `static` related routes were very unintuitive. Though only ingress filtering is enabled, it still required the user to give a lot of information intended for a future implementation of egress filtering.

I wrote those tests, fixed crashes and changed those static related routes.