### PR TITLE
Fix event timing

### DIFF
--- a/vnet/lib/vnet/node_api/base.rb
+++ b/vnet/lib/vnet/node_api/base.rb
@@ -21,42 +21,37 @@ module Vnet::NodeApi
       end
 
       def execute(method_name, *args, &block)
-        Celluloid.logger.debug "#{self.name}.method_missing #{method_name} #{args}"
+        # Celluloid.logger.debug "#{self.name}.execute #{method_name} #{args}"
 
         to_hash(self.__send__(method_name, *args, &block))
       end
 
       # TODO: Make 'execute_batch' only work for sequel model calls.
       def execute_batch(*args)
-        Celluloid.logger.debug "#{self.name}.execute_batch #{args}"
+        # Celluloid.logger.debug "#{self.name}.execute_batch #{args}"
 
         methods = args.dup
         options = methods.last.is_a?(Hash) ? methods.pop : {}
 
-        transaction {
-          to_hash(methods.inject(self) do |klass, method|
+        to_hash(methods.inject(self) do |klass, method|
             name, *args = method
             klass.__send__(name, *args)
           end, options)
-        }
       end
 
       # TODO: Look into why calling node_api methods like 'destroy'
       # goes through method_missing.
       def method_missing(method_name, *args, &block)
         if model_class.respond_to?(method_name)
-          Celluloid.logger.debug "#{self.name}.method_missing m_cls #{method_name} #{args}"
+          # Celluloid.logger.debug "model_class #{self.name}.method_missing #{method_name} #{args}"
 
           define_singleton_method(method_name) { |*args|
-            transaction do
-              model_class.__send__(method_name, *args, &block)
-            end
+            # Celluloid.logger.debug "singleton #{model_class.name}.#{method_name} #{args}"
+            model_class.__send__(method_name, *args, &block)
           }
 
           self.__send__(method_name, *args, &block)
         else
-          Celluloid.logger.debug "#{self.name}.method_missing super #{method_name} #{args}"
-
           super
         end
       end

--- a/vnet/lib/vnet/node_api/base.rb
+++ b/vnet/lib/vnet/node_api/base.rb
@@ -21,29 +21,42 @@ module Vnet::NodeApi
       end
 
       def execute(method_name, *args, &block)
+        Celluloid.logger.debug "#{self.name}.method_missing #{method_name} #{args}"
+
         to_hash(self.__send__(method_name, *args, &block))
       end
 
+      # TODO: Make 'execute_batch' only work for sequel model calls.
       def execute_batch(*args)
+        Celluloid.logger.debug "#{self.name}.execute_batch #{args}"
+
         methods = args.dup
         options = methods.last.is_a?(Hash) ? methods.pop : {}
-        transaction do
+
+        transaction {
           to_hash(methods.inject(self) do |klass, method|
             name, *args = method
             klass.__send__(name, *args)
           end, options)
-        end
+        }
       end
 
+      # TODO: Look into why calling node_api methods like 'destroy'
+      # goes through method_missing.
       def method_missing(method_name, *args, &block)
         if model_class.respond_to?(method_name)
-          define_singleton_method(method_name) do |*args|
+          Celluloid.logger.debug "#{self.name}.method_missing m_cls #{method_name} #{args}"
+
+          define_singleton_method(method_name) { |*args|
             transaction do
               model_class.__send__(method_name, *args, &block)
             end
-          end
+          }
+
           self.__send__(method_name, *args, &block)
         else
+          Celluloid.logger.debug "#{self.name}.method_missing super #{method_name} #{args}"
+
           super
         end
       end

--- a/vnet/lib/vnet/node_api/base.rb
+++ b/vnet/lib/vnet/node_api/base.rb
@@ -21,15 +21,11 @@ module Vnet::NodeApi
       end
 
       def execute(method_name, *args, &block)
-        # Celluloid.logger.debug "#{self.name}.execute #{method_name} #{args}"
-
         to_hash(self.__send__(method_name, *args, &block))
       end
 
       # TODO: Make 'execute_batch' only work for sequel model calls.
       def execute_batch(*args)
-        # Celluloid.logger.debug "#{self.name}.execute_batch #{args}"
-
         methods = args.dup
         options = methods.last.is_a?(Hash) ? methods.pop : {}
 
@@ -43,10 +39,7 @@ module Vnet::NodeApi
       # goes through method_missing.
       def method_missing(method_name, *args, &block)
         if model_class.respond_to?(method_name)
-          # Celluloid.logger.debug "model_class #{self.name}.method_missing #{method_name} #{args}"
-
           define_singleton_method(method_name) { |*args|
-            # Celluloid.logger.debug "singleton #{model_class.name}.#{method_name} #{args}"
             model_class.__send__(method_name, *args, &block)
           }
 

--- a/vnet/lib/vnet/node_api/event_base.rb
+++ b/vnet/lib/vnet/node_api/event_base.rb
@@ -40,14 +40,8 @@ module Vnet::NodeApi
       end
 
       def destroy(filter, options = {})
-        # Celluloid.logger.debug "#{self.name}.node_api.destroy #{filter}"
-
         destroy_with_transaction(filter).tap { |model|
           next if model.nil?
-
-          # TODO: Verify that it's been destroyed. However this will
-          # have issues with the transaction, so call sync query.
-
           dispatch_deleted_item_events(model)
         }
       end
@@ -104,17 +98,10 @@ module Vnet::NodeApi
       #
 
       def plugin(plugin, *args, &block)
-        #Celluloid.logger.debug "#{self.name}.plugin #{plugin.name} #{args}"
-
         extend(plugin::ClassMethods)
         include(plugin::InstanceMethods)
       end
 
-      # Install mode module as Sequel plugin.
-      #
-      # class Foo < Base
-      #   valid_update_fields [:foo, :bar]
-      # end
       def valid_update_fields(fields)
         return if self == Base
 
@@ -175,11 +162,6 @@ module Vnet::NodeApi
       end
 
       def internal_destroy(model)
-        # Celluloid.logger.debug "#{self.name}.pre-model.destroy"
-        # (model && model.destroy).tap { |m|
-        #   Celluloid.logger.debug "#{self.name}.post-model.destroy"
-        # }
-
         model && model.destroy
       end
 

--- a/vnet/lib/vnet/node_api/event_base.rb
+++ b/vnet/lib/vnet/node_api/event_base.rb
@@ -43,8 +43,14 @@ module Vnet::NodeApi
       end
 
       def destroy(filter, options = {})
+        Celluloid.logger.debug "XXXXXXX node_api.destroy #{filter}"
+
         destroy_with_transaction(filter).tap { |model|
           next if model.nil?
+
+          # TODO: Verify that it's been destroyed. However this will
+          # have issues with the transaction, so call sync query.
+
           dispatch_deleted_item_events(model)
         }
       end
@@ -100,6 +106,25 @@ module Vnet::NodeApi
       # Internal methods:
       #
 
+      def plugin(plugin, *args, &block)
+        #Celluloid.logger.debug "XXXXXXX #{self.name}.plugin #{plugin.name} #{args}"
+
+        extend(plugin::ClassMethods)
+        include(plugin::InstanceMethods)
+      end
+
+      # Install mode module as Sequel plugin.
+      #
+      # class Foo < Base
+      #   valid_update_fields [:foo, :bar]
+      # end
+      def valid_update_fields(fields)
+        return if self == Base
+
+        self.plugin BaseValidateUpdateFields
+        self.set_valid_update_fields(fields)
+      end
+
       private
 
       #
@@ -153,6 +178,11 @@ module Vnet::NodeApi
       end
 
       def internal_destroy(model)
+        # Celluloid.logger.debug "#{self.name}.pre-model.destroy"
+        # (model && model.destroy).tap { |m|
+        #   Celluloid.logger.debug "#{self.name}.post-model.destroy"
+        # }
+
         model && model.destroy
       end
 
@@ -206,24 +236,6 @@ module Vnet::NodeApi
         else
           filter
         end
-      end
-
-      def inherited(klass)
-        super
-        klass.class_eval {
-
-          # Install mode module as Sequel plugin.
-          #
-          # class Foo < Base
-          #   valid_update_fields [:foo, :bar]
-          # end
-          def self.valid_update_fields(fields)
-            return if self == Base
-
-            self.plugin BaseValidateUpdateFields
-            self.set_valid_update_fields(fields)
-          end
-        }
       end
 
     end

--- a/vnet/lib/vnet/node_api/event_base.rb
+++ b/vnet/lib/vnet/node_api/event_base.rb
@@ -36,14 +36,11 @@ module Vnet::NodeApi
       end
       
       def update_model_deleted()
-
 	#TODO: Update deleted items
-
-
       end
 
       def destroy(filter, options = {})
-        Celluloid.logger.debug "XXXXXXX node_api.destroy #{filter}"
+        # Celluloid.logger.debug "#{self.name}.node_api.destroy #{filter}"
 
         destroy_with_transaction(filter).tap { |model|
           next if model.nil?
@@ -107,7 +104,7 @@ module Vnet::NodeApi
       #
 
       def plugin(plugin, *args, &block)
-        #Celluloid.logger.debug "XXXXXXX #{self.name}.plugin #{plugin.name} #{args}"
+        #Celluloid.logger.debug "#{self.name}.plugin #{plugin.name} #{args}"
 
         extend(plugin::ClassMethods)
         include(plugin::InstanceMethods)
@@ -195,7 +192,6 @@ module Vnet::NodeApi
           }
         }
 
-        # return if model.update(changes).nil?
         return [model, {}] if model.update(changes).nil?
 
         old_values.keep_if { |key, old_value|


### PR DESCRIPTION
Don't call transaction block by default in node_api as that is handled by the specific classes when needed.