### PR TITLE
Fix network ip lease deletion

### DIFF
--- a/vnet/lib/sequel/plugins/mac_address.rb
+++ b/vnet/lib/sequel/plugins/mac_address.rb
@@ -6,7 +6,7 @@ module Sequel
       def self.apply(model, opts = OPTS)
         association_name = (opts[:attr_name] ? :mac_address : :_mac_address)
         mac_address_attr_name = opts[:attr_name] || :mac_address
-        
+
         model.many_to_one association_name, class: model.name.split(/::/).tap{|n| n[-1] = "MacAddress"}.join("::"), key: :mac_address_id
         model.many_to_many :segments, :join_table => :mac_addresses, :left_key => :id, :left_primary_key => :mac_address_id, :right_key => :segment_id
 

--- a/vnet/lib/vnet/models/mac_address.rb
+++ b/vnet/lib/vnet/models/mac_address.rb
@@ -6,6 +6,7 @@ module Vnet::Models
 
     plugin :paranoia_is_deleted
 
+    many_to_one :segment
     one_to_one :mac_lease
 
   end

--- a/vnet/lib/vnet/models/network.rb
+++ b/vnet/lib/vnet/models/network.rb
@@ -45,6 +45,8 @@ module Vnet::Models
     def before_destroy
       # the association_dependencies plugin doesn't allow us to destroy because it's a many to many relation
       self.ip_leases.each { |lease| lease.destroy }
+
+      super
     end
 
     def before_create

--- a/vnet/lib/vnet/models/segment.rb
+++ b/vnet/lib/vnet/models/segment.rb
@@ -13,6 +13,15 @@ module Vnet::Models
     one_to_many :interface_segments
     one_to_many :topology_segments
 
+    one_to_many :mac_addresses
+    # Really a one to many relation but we're using many_to_many so sequel will let us use a join table
+    many_to_many :mac_leases, :join_table => :mac_addresses,
+                              :left_key => :segment_id,
+                              :left_primary_key => :id,
+                              :right_key => :id,
+                              :right_primary_key => :mac_address_id,
+                              :conditions => "mac_leases.deleted_at is null"
+
     plugin :association_dependencies,
     # 0010_segment
     datapath_segments: :destroy,
@@ -20,6 +29,13 @@ module Vnet::Models
     topology_segments: :destroy,
     # 0011_assoc_interface
     interface_segments: :destroy
+
+    def before_destroy
+      # the association_dependencies plugin doesn't allow us to destroy because it's a many to many relation
+      self.mac_leases.each { |lease| lease.destroy }
+
+      super
+    end
 
   end
 end

--- a/vnet/lib/vnet/node_api/event_base.rb
+++ b/vnet/lib/vnet/node_api/event_base.rb
@@ -34,7 +34,7 @@ module Vnet::NodeApi
           return model
         }
       end
-      
+
       def update_model_deleted()
 	#TODO: Update deleted items
       end

--- a/vnet/lib/vnet/node_api/interface.rb
+++ b/vnet/lib/vnet/node_api/interface.rb
@@ -70,7 +70,7 @@ module Vnet::NodeApi
         Translation.dispatch_deleted_where(filter, model.deleted_at)
         # 0002_services
         # lease_policy_base_interfaces: :destroy,
-        # 0011_assoc_interface 
+        # 0011_assoc_interface
         # TODO: Make the assoc managers subscribe to INTERFACE_DELETED_ITEM(?).
         InterfaceNetwork.dispatch_deleted_where(filter, model.deleted_at)
         InterfaceSegment.dispatch_deleted_where(filter, model.deleted_at)

--- a/vnet/lib/vnet/node_api/ip_lease.rb
+++ b/vnet/lib/vnet/node_api/ip_lease.rb
@@ -40,7 +40,7 @@ module Vnet::NodeApi
         mac_lease_id = options[:mac_lease_id]
 
         transaction {
-          handle_new_uuid(options)          
+          handle_new_uuid(options)
 
           if interface_id || mac_lease_id
             interface, mac_lease = get_if_and_ml(interface_id, mac_lease_id)
@@ -141,7 +141,7 @@ module Vnet::NodeApi
             ip_retention.save_changes
           end
         }
-        
+
         dispatch_event(INTERFACE_LEASED_IPV4_ADDRESS, prepare_lease_event(model))
         model
       end
@@ -199,7 +199,7 @@ module Vnet::NodeApi
 
         interface = interface_id && M::Interface[id: interface_id]
         mac_lease = mac_lease_id && M::MacLease[id: mac_lease_id]
-        
+
         if interface && mac_lease.nil? && mac_lease_id.nil?
           # Error if the interface has more than one mac_lease?
           mac_lease = interface.mac_leases.first

--- a/vnet/lib/vnet/node_api/ip_lease.rb
+++ b/vnet/lib/vnet/node_api/ip_lease.rb
@@ -34,7 +34,6 @@ module Vnet::NodeApi
         ip_address_ds = M::IpAddress.with_deleted.where(network_id: network_id)
 
         M::IpLease.with_deleted.where(ip_address: ip_address_ds).where(*filter_date).each { |lease|
-          p "dispatching for lease: #{lease.canonical_uuid}"
           dispatch_deleted_item_events(lease)
         }
       end

--- a/vnet/lib/vnet/node_api/mac_lease.rb
+++ b/vnet/lib/vnet/node_api/mac_lease.rb
@@ -10,6 +10,8 @@ module Vnet::NodeApi
         filter_date = ['deleted_at >= ? || deleted_at = NULL',
                        (deleted_at || Time.now) - 3]
 
+        # I wanted to use a dataset here like I did in NodeApi::IpLease to keep it all SQL.
+        # Unfortunately this didn't quite work out due to how the mac_address plugin is written.
         mac_address_ids = M::MacAddress.with_deleted.where(segment_id: segment_id).map { |ma| ma.id }
 
         M::MacLease.with_deleted.where(mac_address_id: mac_address_ids).where(*filter_date).each { |lease|

--- a/vnet/lib/vnet/node_api/mac_lease.rb
+++ b/vnet/lib/vnet/node_api/mac_lease.rb
@@ -6,6 +6,17 @@ module Vnet::NodeApi
 
     class << self
 
+      def dispatch_deleted_for_segment(segment_id, deleted_at)
+        filter_date = ['deleted_at >= ? || deleted_at = NULL',
+                       (deleted_at || Time.now) - 3]
+
+        mac_address_ids = M::MacAddress.with_deleted.where(segment_id: segment_id).map { |ma| ma.id }
+
+        M::MacLease.with_deleted.where(mac_address_id: mac_address_ids).where(*filter_date).each { |lease|
+          dispatch_deleted_item_events(lease)
+        }
+      end
+
       #
       # Internal methods:
       #

--- a/vnet/lib/vnet/node_api/network.rb
+++ b/vnet/lib/vnet/node_api/network.rb
@@ -42,7 +42,7 @@ module Vnet::NodeApi
         ActiveNetwork.dispatch_deleted_where(filter, model.deleted_at)
         DatapathNetwork.dispatch_deleted_where(filter, model.deleted_at)
         Route.dispatch_deleted_where(filter, model.deleted_at)
-        model.ip_leases.each {  |lease| IpLease.dispatch_deleted_for_model(lease) }
+        IpLease.dispatch_deleted_for_network(model.id, model.deleted_at)
         # 0002_services
         # LeasePolicyBaseNetwork.dispatch_deleted_where(filter, model.deleted_at)
         # 0009_topology

--- a/vnet/lib/vnet/node_api/network.rb
+++ b/vnet/lib/vnet/node_api/network.rb
@@ -40,9 +40,9 @@ module Vnet::NodeApi
 
         # 0001_origin
         ActiveNetwork.dispatch_deleted_where(filter, model.deleted_at)
-        # IpAddresses.dispatch_deleted_where(filter, model.deleted_at) # Needed? We're deleting the network.
         DatapathNetwork.dispatch_deleted_where(filter, model.deleted_at)
         Route.dispatch_deleted_where(filter, model.deleted_at)
+        model.ip_leases.each {  |lease| IpLease.dispatch_deleted_for_model(lease) }
         # 0002_services
         # LeasePolicyBaseNetwork.dispatch_deleted_where(filter, model.deleted_at)
         # 0009_topology

--- a/vnet/lib/vnet/node_api/segment.rb
+++ b/vnet/lib/vnet/node_api/segment.rb
@@ -37,6 +37,8 @@ module Vnet::NodeApi
 
         # 0009_topology
         TopologySegment.dispatch_deleted_where(filter, model.deleted_at)
+        # 0010_segment
+        MacLease.dispatch_deleted_for_segment(model.id, model.deleted_at)
         # 0011_assoc_interface
         InterfaceSegment.dispatch_deleted_where(filter, model.deleted_at)
       end

--- a/vnet/spec/fabricators/mac_lease_fabricator.rb
+++ b/vnet/spec/fabricators/mac_lease_fabricator.rb
@@ -24,3 +24,12 @@ Fabricator(:mac_lease_free, class_name: Vnet::Models::MacLease) do
 
   mac_address { sequence(:mac_address, 0) }
 end
+
+Fabricator(:mac_lease_with_segment, class_name: Vnet::Models::MacLease) do
+  id { id_sequence(:mac_lease_ids) }
+
+  segment_id { Fabricate(:segment).id }
+  mac_address_id { |attrs|
+    Fabricate(:mac_address, segment_id: attrs[:segment_id]).id
+  }
+end

--- a/vnet/spec/vnet/endpoints/1.0/networks_spec.rb
+++ b/vnet/spec/vnet/endpoints/1.0/networks_spec.rb
@@ -21,31 +21,6 @@ describe '/networks' do
   include_examples 'GET /:uuid'
   include_examples 'DELETE /:uuid'
 
-  describe 'DELETE /:uuid' do
-    context 'With ip leases in the database' do
-      let(:test_network) { Fabricate(:network) }
-
-      before(:each) {
-        3.times { Fabricate(:ip_lease, network_id: test_network.id) }
-
-        delete "#{api_suffix}/#{test_network.canonical_uuid}"
-      }
-
-      it "deletes all the ip leases along with the network" do
-        expect(last_response).to succeed
-
-        expect(model_class[test_network.canonical_uuid]).to eq(nil)
-        expect(model_class.with_deleted.where(uuid: test_network.uuid)).not_to eq(nil)
-
-        expect(Vnet::Models::IpLease.count).to eq(0)
-        expect(Vnet::Models::IpLease.with_deleted.count).to eq(3)
-
-        expect(Vnet::Models::IpAddress.where(network: test_network).count).to eq(0)
-        expect(Vnet::Models::IpAddress.with_deleted.where(network: test_network).count).to eq(3)
-      end
-    end
-  end
-
   describe 'POST /' do
     let!(:topology) { Fabricate(:topology) { uuid 'topo-test' }  }
 

--- a/vnet/spec/vnet/models/network_spec.rb
+++ b/vnet/spec/vnet/models/network_spec.rb
@@ -83,6 +83,22 @@ describe Vnet::Models::Network do
       expect(subject.datapath_networks).to be_empty
       expect(subject.routes).to be_empty
     end
+
+    it "deletes associated ip leases and ip addresses" do
+      nw = Fabricate(:network)
+      3.times { Fabricate(:ip_lease, network_id: nw.id) }
+
+      nw.destroy
+
+      expect(Vnet::Models::Network[nw.canonical_uuid]).to eq(nil)
+      expect(Vnet::Models::Network.with_deleted.where(uuid: nw.uuid)).not_to eq(nil)
+
+      expect(nw.ip_leases_dataset.count).to eq(0)
+      expect(nw.ip_leases_dataset.unfiltered.count).to eq(3)
+
+      expect(Vnet::Models::IpAddress.where(network: nw).count).to eq(0)
+      expect(Vnet::Models::IpAddress.with_deleted.where(network: nw).count).to eq(3)
+    end
   end
 
 end

--- a/vnet/spec/vnet/models/segment_spec.rb
+++ b/vnet/spec/vnet/models/segment_spec.rb
@@ -18,5 +18,24 @@ describe Vnet::Models::Segment do
       expect(Vnet::Models::MacAddress.where(segment: sgm).count).to eq(0)
       expect(Vnet::Models::MacAddress.with_deleted.where(segment: sgm).count).to eq(3)
     end
+
+    it "deletes associated networks (and in turn, ip_leases)" do
+      sgm = Fabricate(:segment)
+      3.times {
+        nw = Fabricate(:network, segment_id: sgm.id)
+        3.times {Fabricate(:ip_lease, network_id: nw.id) }
+      }
+
+      sgm.destroy
+
+      expect(Vnet::Models::Segment[sgm.canonical_uuid]).to eq(nil)
+      expect(Vnet::Models::Segment.with_deleted.where(uuid: sgm.uuid)).not_to eq(nil)
+
+      expect(Vnet::Models::Network.count).to eq(0)
+      expect(Vnet::Models::Network.with_deleted.count).to eq(3)
+
+      expect(Vnet::Models::IpLease.count).to eq(0)
+      expect(Vnet::Models::IpLease.with_deleted.count).to eq(9)
+    end
   end
 end

--- a/vnet/spec/vnet/models/segment_spec.rb
+++ b/vnet/spec/vnet/models/segment_spec.rb
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+require 'spec_helper'
+
+describe Vnet::Models::Segment do
+  describe "destroy" do
+    it "deletes associated mac_leases and mac_addresses" do
+      sgm = Fabricate(:segment)
+      3.times { Fabricate(:mac_lease_with_segment, segment_id: sgm.id) }
+
+      sgm.destroy
+
+      expect(Vnet::Models::Segment[sgm.canonical_uuid]).to eq(nil)
+      expect(Vnet::Models::Segment.with_deleted.where(uuid: sgm.uuid)).not_to eq(nil)
+
+      expect(Vnet::Models::MacLease.count).to eq(0)
+      expect(Vnet::Models::MacLease.with_deleted.count).to eq(3)
+
+      expect(Vnet::Models::MacAddress.where(segment: sgm).count).to eq(0)
+      expect(Vnet::Models::MacAddress.with_deleted.where(segment: sgm).count).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
Fixed the following bug:

* Imagine we have interface `if-aaa` in network `nw-bbb` with ip address `x.x.x.x`.
* Next we delete network `nw-bbb`.
* Now in the database the `ip_address` for x.x.x.x got destroyed but the `ip_lease` remained.
* Next time we did `vnctl show if-aaa` the webapi saw that if-aaa has an `ip_lease` and tried access the `ip_address` associated with it and display the `network` accociated with that. Since both of those have been deleted, the web api crashed with a nilclass error.

It resulted in the follow error in the log:

```
Apr 18 07:10:36 ci vnet-webapi[1047]: 172.16.3.11 - - [18/Apr/2017:07:10:36 +0000] "GET /api/interfaces/if-aaa HTTP/1.1" 200 617 0.0245
Apr 18 07:10:36 ci vnet-webapi[1047]: 2017-04-18 07:10:36 - NoMethodError - undefined method `network' for nil:NilClass:
Apr 18 07:10:36 ci vnet-webapi[1047]: /opt/axsh/openvnet/vnet/lib/vnet/endpoints/1.0/responses/interface.rb:13:in `block in generate'
Apr 18 07:10:36 ci vnet-webapi[1047]: /opt/axsh/openvnet/vnet/lib/vnet/endpoints/1.0/responses/interface.rb:11:in `map'
Apr 18 07:10:36 ci vnet-webapi[1047]: /opt/axsh/openvnet/vnet/lib/vnet/endpoints/1.0/responses/interface.rb:11:in `generate'
```

I fixed it by making networks destroy their ip_leases which in turn destroy the ip_addresses.