### PR TITLE
Fix gc permission issue

### DIFF
--- a/ci/ci.el6/rspec_rpmbuild/build.sh
+++ b/ci/ci.el6/rspec_rpmbuild/build.sh
@@ -63,7 +63,8 @@ docker attach $CID
 
 tar -cO --directory="${REPO_BASE_DIR}" "${BRANCH}" | $SSH_REMOTE tar -xf - -C "${REPO_BASE_DIR}"
 
+# Set the group with write permissions so the garbage collection job can delete these later
 $SSH_REMOTE /bin/bash <<EOS
-chgrp -R repoci "${RPM_ABSOLUTE}"
-chmod -R g+w "${RPM_ABSOLUTE}"
+chgrp -R repoci "${REPO_BASE_DIR}"
+chmod -R g+w "${REPO_BASE_DIR}"
 EOS

--- a/ci/ci.el6/rspec_rpmbuild/build.sh
+++ b/ci/ci.el6/rspec_rpmbuild/build.sh
@@ -62,3 +62,8 @@ CID=$(docker run -v "${REPO_BASE_DIR}:/repos" -v "${BUILD_CACHE_DIR}:/cache" ${B
 docker attach $CID
 
 tar -cO --directory="${REPO_BASE_DIR}" "${BRANCH}" | $SSH_REMOTE tar -xf - -C "${REPO_BASE_DIR}"
+
+$SSH_REMOTE /bin/bash <<EOS
+chgrp -R repoci "${RPM_ABSOLUTE}"
+chmod -R g+w "${RPM_ABSOLUTE}"
+EOS

--- a/ci/ci.el7/rspec_rpmbuild/build.sh
+++ b/ci/ci.el7/rspec_rpmbuild/build.sh
@@ -62,3 +62,9 @@ CID=$(docker run -v "${REPO_BASE_DIR}:/repos" -v "${BUILD_CACHE_DIR}:/cache" ${B
 docker attach $CID
 
 tar -cO --directory="${REPO_BASE_DIR}" "${BRANCH}" | $SSH_REMOTE tar -xf - -C "${REPO_BASE_DIR}"
+
+# Set the group with write permissions so the garbage collection job can delete these later
+$SSH_REMOTE /bin/bash <<EOS
+chgrp -R repoci "${RPM_ABSOLUTE}"
+chmod -R g+w "${RPM_ABSOLUTE}"
+EOS

--- a/ci/ci.el7/rspec_rpmbuild/build.sh
+++ b/ci/ci.el7/rspec_rpmbuild/build.sh
@@ -65,6 +65,6 @@ tar -cO --directory="${REPO_BASE_DIR}" "${BRANCH}" | $SSH_REMOTE tar -xf - -C "$
 
 # Set the group with write permissions so the garbage collection job can delete these later
 $SSH_REMOTE /bin/bash <<EOS
-chgrp -R repoci "${RPM_ABSOLUTE}"
-chmod -R g+w "${RPM_ABSOLUTE}"
+chgrp -R repoci "${REPO_BASE_DIR}"
+chmod -R g+w "${REPO_BASE_DIR}"
 EOS


### PR DESCRIPTION
The group permissions weren't set correctly for the branch yum repositories and because of this the CI's garbage collection couldn't delete them when needed. https://ci.openvnet.org/job/garbage_collection/42/console

Fixed that.