### PR TITLE
Use rake to create the rspec test database

### DIFF
--- a/ci/ci.el6/rspec_rpmbuild/build_packages_vnet.sh
+++ b/ci/ci.el6/rspec_rpmbuild/build_packages_vnet.sh
@@ -93,9 +93,9 @@ try_load_cache "${BUILD_CACHE_DIR}" "${CACHE_VOLUME}" "${COMMIT_ID}"
 
 (
     cd vnet
-    mysqladmin -uroot create vnet_test
     bundle install --path vendor/bundle --standalone
-    bundle exec rake test:db:reset
+    bundle exec rake test:db:create
+    bundle exec rake test:db:init
     bundle exec rspec spec
 )
 

--- a/ci/ci.el7/rspec_rpmbuild/build_packages_vnet.sh
+++ b/ci/ci.el7/rspec_rpmbuild/build_packages_vnet.sh
@@ -93,9 +93,9 @@ try_load_cache "${BUILD_CACHE_DIR}" "${CACHE_VOLUME}" "${COMMIT_ID}"
 
 (
     cd vnet
-    mysqladmin -uroot create vnet_test
     bundle install --path vendor/bundle --standalone
-    bundle exec rake test:db:reset
+    bundle exec rake test:db:create
+    bundle exec rake test:db:init
     bundle exec rspec spec
 )
 


### PR DESCRIPTION
Just a tiny fix. Creating the database through mysqladmin worked just fine but I think it is better to use rake so we notice if rake's db creation ever breaks.