### PR TITLE
Fixed inconsistent error format

### DIFF
--- a/vnet/lib/sinatra/vnet_api_setup.rb
+++ b/vnet/lib/sinatra/vnet_api_setup.rb
@@ -81,7 +81,7 @@ module Sinatra
 
       error do |boom|
         logger.error("API Error: #{request.path_info} -> #{boom.class}: #{boom.message} (#{boom.backtrace.first})")
-        respond_with({:error=>boom.class.to_s, :message=>boom.message, :code=>500})
+        respond_with({:error=>boom.class.to_s, :message=>boom.message, :code=>'500'})
       end
     }
 


### PR DESCRIPTION
I was getting the following error when calling OpenVNet from terraform.

```
* openvnet_datapath.dp_sample: json: cannot unmarshal number into Go struct field OpenVNetError.code of type string  
```

The problem was that all explicitly defined error codes are returned as strings but our generic `500: internal server error` was returned numerically. I changed that one to string as well to be consistent with the rest. With this change the go client works as expected.