### PR TITLE
Update rubocop

### DIFF
--- a/vnet/Gemfile
+++ b/vnet/Gemfile
@@ -22,7 +22,7 @@ gem "sinatra-contrib"
 gem "sinatra-hashfix"
 gem "sinatra-browse", ">= 0.6.1" # 0.5 and 0.6 have a bug where missing parameters would be set to nil values
 gem "unicorn"
-gem "activesupport", '3.2.22.5' # Updating to 4.2.1 broke the unit tests.
+gem "activesupport"
 
 # trema and build requirement gems
 gem 'paper_house'

--- a/vnet/Gemfile
+++ b/vnet/Gemfile
@@ -43,5 +43,5 @@ group :development, :test do
 end
 
 group :metrics do
-  gem 'rubocop', '0.36.0'
+  gem 'rubocop'
 end

--- a/vnet/Gemfile.lock
+++ b/vnet/Gemfile.lock
@@ -27,9 +27,11 @@ GEM
       Platform (>= 0.4.0)
       open4
     Platform (0.4.0)
-    activesupport (3.2.22.5)
-      i18n (~> 0.6, >= 0.6.4)
-      multi_json (~> 1.0)
+    activesupport (5.1.5)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     ast (2.3.0)
@@ -82,12 +84,13 @@ GEM
     http (0.5.1)
       http_parser.rb
     http_parser.rb (0.6.0)
-    i18n (0.9.3)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     ipaddress (0.8.3)
     json (2.1.0)
     kgio (2.11.1)
     method_source (0.9.0)
+    minitest (5.11.3)
     multi_json (1.13.1)
     mysql2 (0.4.10)
     net-dhcp (1.3.3)
@@ -172,10 +175,13 @@ GEM
     term-ansicolor (1.6.0)
       tins (~> 1.0)
     thor (0.19.4)
+    thread_safe (0.3.6)
     tilt (2.0.8)
     timers (4.0.4)
       hitimes
     tins (1.16.3)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
     unicorn (5.4.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -189,7 +195,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (= 3.2.22.5)
+  activesupport
   bit-struct (>= 0.13.7)
   celluloid (= 0.16.0)
   celluloid-io (= 0.16.2)

--- a/vnet/Gemfile.lock
+++ b/vnet/Gemfile.lock
@@ -34,7 +34,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    ast (2.3.0)
+    ast (2.4.0)
     backports (3.11.0)
     bindata (2.1.0)
     bit-struct (0.16)
@@ -100,8 +100,9 @@ GEM
     paper_house (0.6.2)
       POpen4 (~> 0.1.4)
       rake
-    parser (2.4.0.2)
-      ast (~> 2.3)
+    parallel (1.12.1)
+    parser (2.5.0.2)
+      ast (~> 2.4.0)
     pio (0.28.1)
       bindata (~> 2.1.0)
     powerpack (0.1.1)
@@ -118,8 +119,7 @@ GEM
       rack
     rack-test (0.8.2)
       rack (>= 1.0, < 3)
-    rainbow (2.2.2)
-      rake
+    rainbow (3.0.0)
     raindrops (0.19.0)
     rake (10.1.0)
     redis (4.0.1)
@@ -144,11 +144,13 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
-    rubocop (0.36.0)
-      parser (>= 2.3.0.0, < 3.0)
+    rubocop (0.52.1)
+      parallel (~> 1.10)
+      parser (>= 2.4.0.2, < 3.0)
       powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
+      rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
     safe_yaml (1.0.4)
     sequel (4.8.0)
@@ -182,6 +184,7 @@ GEM
     tins (1.16.3)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    unicode-display_width (1.3.0)
     unicorn (5.4.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -220,7 +223,7 @@ DEPENDENCIES
   rake (= 10.1.0)
   rant (>= 0.5.9)!
   rspec
-  rubocop (= 0.36.0)
+  rubocop
   sequel (= 4.8.0)
   sequel_paranoia
   sinatra (= 1.4.7)

--- a/vnet/lib/vnet.rb
+++ b/vnet/lib/vnet.rb
@@ -5,6 +5,7 @@
 require 'active_support/core_ext/class/attribute_accessors'
 require 'active_support/core_ext/module/attribute_accessors'
 require 'active_support/core_ext/object'
+require 'active_support/json/encoding.rb'
 require 'active_support/hash_with_indifferent_access'
 require 'active_support/inflector'
 require 'ext/kernel'


### PR DESCRIPTION
Includes https://github.com/axsh/openvnet/pull/548

In addition to activesupport in #548, I also updated rubocop in this PR. It was fixed at a version containing a security issue and there was no comment explaining the version fix. That's why I've kept this pull request separate from the activesupport update. If there's anything that needs to be done in addition to this update, let me know.