### PR TITLE
Two pass integration test

### DIFF
--- a/integration_test/config/base.yml
+++ b/integration_test/config/base.yml
@@ -25,6 +25,7 @@ log_level: info
 vm_http_proxy: http://10.50.0.2:3128
 dump_flows: true
 aggregate_logs: true
+vna_start_time: :after
 
 api_adapter: :vnctl
 

--- a/integration_test/lib/vnspec/config.rb
+++ b/integration_test/lib/vnspec/config.rb
@@ -12,7 +12,11 @@ module Vnspec
       log_level: :info,
       vna_waittime: 0,
       ssh_quiet_mode: false,
-      aggregate_logs: true
+      aggregate_logs: true,
+      # Can be :before or :after to start VNA before or after
+      # all entries in the OpenVNet database have been made.
+      # Setting it to :both will cause both cases to be tested.
+      vna_start_time: :both
     }
 
     class << self

--- a/integration_test/lib/vnspec/config.rb
+++ b/integration_test/lib/vnspec/config.rb
@@ -33,13 +33,11 @@ module Vnspec
           end
         end
 
-        if vna_start_time = ENV['VNA_START_TIME']
-          valid = ['before', 'after', 'both']
-          if !valid.member?(vna_start_time)
-            raise "Invalid VNA start time: '#{vna_start_time}'. Valid start times are: #{valid}"
-          end
+        @config[:vna_start_time] = vna_start_time.to_sym if vna_start_time = ENV['VNA_START_TIME']
 
-          @config[:vna_start_time] = vna_start_time.to_sym
+        valid = [:before, :after, :both]
+        if !valid.member?(@config[:vna_start_time])
+          raise "Invalid VNA start time: '#{@config[:vna_start_time]}'. Valid start times are: #{valid}"
         end
 
         @config

--- a/integration_test/lib/vnspec/config.rb
+++ b/integration_test/lib/vnspec/config.rb
@@ -32,6 +32,16 @@ module Vnspec
             @config.merge!(YAML.load_file(file).symbolize_keys)
           end
         end
+
+        if vna_start_time = ENV['VNA_START_TIME']
+          valid = ['before', 'after', 'both']
+          if !valid.member?(vna_start_time)
+            raise "Invalid VNA start time: '#{vna_start_time}'. Valid start times are: #{valid}"
+          end
+
+          @config[:vna_start_time] = vna_start_time.to_sym
+        end
+
         @config
       end
     end

--- a/integration_test/lib/vnspec/invoker.rb
+++ b/integration_test/lib/vnspec/invoker.rb
@@ -47,7 +47,9 @@ module Vnspec
       statuses = {}
 
       final_result = true
-      vna_start_times.each { |start_time|
+      vna_start_times.each_with_index { |start_time, i|
+        highlighted_log "Pass #{i +1} of #{vna_start_times.length}: VNA started #{start_time} running vnctl commands"
+
         statuses[start_time] = specs.map do |name|
           result = run_specs(name, start_time)
           final_result = false if !result
@@ -71,10 +73,7 @@ module Vnspec
     end
 
     def run_specs(name, vna_start_time = :after)
-      log_string = "Running spec '#{name}. VNA started #{vna_start_time} running vnctl commands"
-      logger.info("\n#=" + ("=" * log_string.length) + "=#")
-      logger.info("# #{log_string} #")
-      logger.info("#=" + ("=" * log_string.length) + "=#\n")
+      highlighted_log "Running spec '#{name}'."
 
       unless VM.ready?(10)
         logger.error("vm not ready")

--- a/integration_test/lib/vnspec/invoker.rb
+++ b/integration_test/lib/vnspec/invoker.rb
@@ -36,6 +36,8 @@ module Vnspec
       if name.to_sym == :all
         specs = config[:specs]
         specs += config[:specs_ext] if config[:specs_ext]
+      else
+        specs = [name]
       end
 
       if config[:vna_start_time] == :both

--- a/integration_test/lib/vnspec/invoker.rb
+++ b/integration_test/lib/vnspec/invoker.rb
@@ -41,7 +41,7 @@ module Vnspec
       if config[:vna_start_time] == :both
         vna_start_times = [:before, :after]
       else
-        vna_start_times = config[:vna_start_time]
+        vna_start_times = [config[:vna_start_time]]
       end
 
       statuses = {}

--- a/integration_test/lib/vnspec/invoker.rb
+++ b/integration_test/lib/vnspec/invoker.rb
@@ -73,11 +73,10 @@ module Vnspec
     end
 
     def run_specs(name, vna_start_time = :after)
-      puts ""
-      puts "#============================================#"
-      puts " Starting VNA #{vna_start_time} running vnctl commands "
-      puts "#============================================#"
-      puts ""
+      log_string = "Starting VNA #{vna_start_time} running vnctl commands"
+      logger.info("\n#=" + ("=" * log_string.length) + "=#")
+      logger.info("# #{log_string} #")
+      logger.info("#=" + ("=" * log_string.length) + "=#\n")
 
       setup(name, vna_start_time)
       sleep(1)

--- a/integration_test/lib/vnspec/invoker.rb
+++ b/integration_test/lib/vnspec/invoker.rb
@@ -46,28 +46,28 @@ module Vnspec
 
       statuses = {}
 
+      final_result = true
       vna_start_times.each { |start_time|
         statuses[start_time] = specs.map do |name|
-          [name, run_specs(name, start_time)]
+          result = run_specs(name, start_time)
+          final_result = false if !result
+
+          [name, result]
         end
       }
 
       vna_start_times.each { |start_time|
-        print_statuses(statuses[start_time], start_time)
+        logger.info("-" * 50)
+        logger.info("VNA started #{start_time} running vnctl commands")
+        logger.info ""
+        statuses[start_time].each do |name, status|
+          logger.info("#{name}: #{status ? "success" : "failure"}")
+        end
+        logger.info("-" * 50)
+        logger.info ""
       }
 
-      statuses.all?{|n, s| s }
-    end
-
-    def print_statuses(statuses, vna_start_time)
-      logger.info("-" * 50)
-      logger.info("VNA started #{vna_start_time} running vnctl commands")
-      logger.info ""
-      statuses.each do |name, status|
-        logger.info("#{name}: #{status ? "success" : "failure"}")
-      end
-      logger.info("-" * 50)
-      logger.info ""
+      final_result
     end
 
     def run_specs(name, vna_start_time = :after)

--- a/integration_test/lib/vnspec/logger.rb
+++ b/integration_test/lib/vnspec/logger.rb
@@ -54,5 +54,11 @@ module Vnspec
       end
       @logger
     end
+
+    def highlighted_log(log_string)
+      logger.info("\n#=" + ("=" * log_string.length) + "=#")
+      logger.info("# #{log_string} #")
+      logger.info("#=" + ("=" * log_string.length) + "=#\n")
+    end
   end
 end

--- a/integration_test/lib/vnspec/spec.rb
+++ b/integration_test/lib/vnspec/spec.rb
@@ -8,15 +8,6 @@ module Vnspec
 
       def exec(name = nil)
         spec_file = name ? "spec/#{name}_spec.rb" : ""
-        logger.info("-" * 50)
-        logger.info("executing spec: #{name}")
-        logger.info("-" * 50)
-
-        #require_relative 'spec/spec_helper'
-        #json_formatter = RSpec.configuration.formatters.find{|f| f.class == RSpec::Core::Formatters::JsonFormatter}
-
-        #RSpec::Core::Runner.run([File.expand_path("../spec/#{name}_spec.rb", __FILE__)])
-        #json_formatter.output_hash.tap {|hash| logger. hash}
 
         system("cd #{File.expand_path(File.dirname(__FILE__))}; bundle exec rspec #{spec_file}")
       end


### PR DESCRIPTION
Updated the integration test to do two passes.

### 1st pass

VNA is started on all hosts **before** the database is populated using vnctl commands.

Execute all specs

### 2nd pass

VNA is started on all hosts **after** the database is populated using vnctl commands.

Execute all specs

### The reason for this

Up until now the integration test only started VNA after all the vnctl commands had been executed. While implementen OpenVNet in several projects, I ran into a lot of bugs that occur only when VNA is started before. In order to reproduce those, I've added the two pass system. Now we have an environment to test against while we fix them.

For now I've set the test a configuration flag to make the integration test run the same as before, starting VNA only after vnctl commands. That way develop can remain green while we fix these problems in other branches.