### PR TITLE
Added some missing cleanup to the close_all_listening_ports function

### DIFF
--- a/integration_test/lib/vnspec/vm.rb
+++ b/integration_test/lib/vnspec/vm.rb
@@ -323,11 +323,10 @@ module Vnspec
       end
 
       def close_all_listening_ports
-        cmds = open_udp_ports.keys.map { |port|
-          "rm -f #{UDP_OUTPUT_DIR}/#{port}*"
-        }
-
-        cmds << "killall nc"
+        cmds = [
+          "rm -f #{UDP_OUTPUT_DIR}/*",
+          "killall nc"
+        ]
 
         @open_tcp_ports.clear
         @open_udp_ports.clear

--- a/integration_test/lib/vnspec/vm.rb
+++ b/integration_test/lib/vnspec/vm.rb
@@ -323,7 +323,16 @@ module Vnspec
       end
 
       def close_all_listening_ports
-        ssh_on_guest("killall nc", use_sudo: true)
+        cmds = open_udp_ports.keys.map { |port|
+          "rm -f #{UDP_OUTPUT_DIR}/#{port}*"
+        }
+
+        cmds << "killall nc"
+
+        @open_tcp_ports.clear
+        @open_udp_ports.clear
+
+        ssh_on_guest(cmds.join(";"), use_sudo: true)
       end
 
       def hostname_for(address, options = {})


### PR DESCRIPTION
I was taking a look at how we did the tcp/udp tests to replicate them in another project and noticed that the `close_all_listening_ports` didn't do a proper cleanup. Figured I might as well quickly fix that.