### PR TITLE
Fix small issues

### DIFF
--- a/vnet/bin/vna
+++ b/vnet/bin/vna
@@ -44,16 +44,16 @@ params = {
 
 params.merge!(:public => conf.node.pub_addr_string) if conf.node.addr.public != ""
 
-DCell.start(params)
-
-
 trap 'TTIN' do
   Celluloid.stack_dump
 end
 
-Vnet::NodeModules::ServiceOpenflow.supervise_as :service_openflow
+Vnet::NodeModules::ServiceOpenflow.prepare_controller(Thread.current).tap { |controller|
+  DCell.start(params)
 
-Celluloid::Actor[:service_openflow].prepare_controller(Thread.current).tap { |controller|
+  Vnet::NodeModules::ServiceOpenflow.supervise_as :service_openflow
+  Celluloid::Actor[:service_openflow].set_controller(controller)
+
   Celluloid.logger.debug "starting trema controller on thread #{Thread.current.inspect}"
   controller.run_no_init!
 }

--- a/vnet/bin/vna
+++ b/vnet/bin/vna
@@ -9,11 +9,18 @@ require 'vnet'
 
 # Start the switch manager before any celluloid services in order to
 # avoid cloned file descriptors to e.g. zmq remaining open.
-switch_manager_new = Vnet::NodeModules::SwitchManager.new
-switch_manager_new.configure_trema
-switch_manager_new.cleanup_current_session
-switch_manager_new.kill_old_switches
-switch_manager_new.start
+Vnet::NodeModules::SwitchManager.new.tap { |sm|
+  sm.configure_trema
+  sm.cleanup_current_session
+  sm.kill_old_switches
+  sm.start
+}
+
+controller = Vnet::Openflow::Controller.new.tap { |controller|
+  controller.init_trema
+  controller.open_trema_tasks
+  controller.trema_thread = Thread.current
+}
 
 require 'celluloid'
 require 'celluloid/autostart'
@@ -49,12 +56,10 @@ trap 'TTIN' do
   Celluloid.stack_dump
 end
 
-Vnet::NodeModules::ServiceOpenflow.prepare_controller(Thread.current).tap { |controller|
-  DCell.start(params)
+DCell.start(params)
 
-  Vnet::NodeModules::ServiceOpenflow.supervise_as :service_openflow
-  Celluloid::Actor[:service_openflow].set_controller(controller)
+Vnet::NodeModules::ServiceOpenflow.supervise_as :service_openflow
+Celluloid::Actor[:service_openflow].set_controller(controller)
 
-  Celluloid.logger.debug "starting trema controller on thread #{Thread.current.inspect}"
-  controller.run_no_init!
-}
+Celluloid.logger.debug "starting trema controller on thread #{Thread.current.inspect}"
+controller.run_no_init!

--- a/vnet/bin/vna
+++ b/vnet/bin/vna
@@ -6,13 +6,6 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'rubygems'
 require 'bundler/setup'
 require 'vnet'
-require 'celluloid'
-require 'celluloid/autostart'
-require 'dcell'
-
-#Vnet::Initializers::Logger.run("vna.log")
-
-conf = Vnet::Configurations::Vna.conf
 
 # Start the switch manager before any celluloid services in order to
 # avoid cloned file descriptors to e.g. zmq remaining open.
@@ -21,6 +14,14 @@ switch_manager_new.configure_trema
 switch_manager_new.cleanup_current_session
 switch_manager_new.kill_old_switches
 switch_manager_new.start
+
+require 'celluloid'
+require 'celluloid/autostart'
+require 'dcell'
+
+#Vnet::Initializers::Logger.run("vna.log")
+
+conf = Vnet::Configurations::Vna.conf
 
 Vnet::NodeApi.set_proxy(conf.node_api_proxy)
 Vnet::NodeApi.raise_on_error = false # dont raise any errors

--- a/vnet/bin/vna
+++ b/vnet/bin/vna
@@ -53,4 +53,7 @@ end
 
 Vnet::NodeModules::ServiceOpenflow.supervise_as :service_openflow
 
-sleep
+Celluloid::Actor[:service_openflow].prepare_controller(Thread.current).tap { |controller|
+  Celluloid.logger.debug "starting trema controller on thread #{Thread.current.inspect}"
+  controller.run_no_init!
+}

--- a/vnet/lib/vnet/node_modules/event_handler.rb
+++ b/vnet/lib/vnet/node_modules/event_handler.rb
@@ -100,13 +100,15 @@ module Vnet::NodeModules
 
       begin
         if DCell.me.id == node_id
+          # debug log_format_h("publish_event(local)->#{node_id}: #{event}", options)
+
           Celluloid::Actor[:service_openflow].dispatch_publish(event, options)
         else
+          # debug log_format_h("publish_event(remote)->#{node_id}: #{event}", options)
+
           DCell::Node[node_id].tap { |node|
             # No need to log as a node being disconnected is normal.
             next if node.nil? || node.state != :connected
-
-            # debug log_format_h("publish_event->#{node_id}: #{event}", options)
 
             if node[:service_openflow].nil?
               warn "publish_event->#{node_id}: no service_openflow registered"

--- a/vnet/lib/vnet/node_modules/event_handler.rb
+++ b/vnet/lib/vnet/node_modules/event_handler.rb
@@ -73,8 +73,18 @@ module Vnet::NodeModules
         end
 
       when *VNMGR_EVENTS
-        # debug log_format_h("publish_event->vnmgr: #{event}", options)
-        DCell::Node[:vnmgr][:vnmgr].publish(event, options)
+        begin
+          # debug log_format_h("publish_event->vnmgr: #{event}", options)
+
+          if DCell.me.id == 'vnmgr'
+            Celluloid::Actor[:vnmgr].dispatch_publish(event, options)
+          else
+            DCell::Node['vnmgr'][:vnmgr].dispatch_publish(event, options)
+          end
+
+        rescue Celluloid::DeadActorError => e
+          info "publish_event->vnmgr: could not send #{event}, vnmgr actor is dead"
+        end
 
       else
         # TODO: Refactor. We should not need to query for every single
@@ -86,19 +96,30 @@ module Vnet::NodeModules
     end
 
     def publish_event(node_id, event, options)
-      DCell::Node[node_id].tap { |node|
-        # No need to log as a node being disconnected is normal.
-        next if node.nil? || node.state != :connected
+      raise "tried to use non-string node_id '#{node_id.inspect}'" if !node_id.is_a? String
 
-        # debug log_format_h("publish_event->#{node_id}: #{event}", options)
+      begin
+        if DCell.me.id == node_id
+          Celluloid::Actor[:service_openflow].dispatch_publish(event, options)
+        else
+          DCell::Node[node_id].tap { |node|
+            # No need to log as a node being disconnected is normal.
+            next if node.nil? || node.state != :connected
 
-        if node[:service_openflow].nil?
-          warn "publish_event->#{node_id}: no service_openflow registered"
-          next
+            # debug log_format_h("publish_event->#{node_id}: #{event}", options)
+
+            if node[:service_openflow].nil?
+              warn "publish_event->#{node_id}: no service_openflow registered"
+              next
+            end
+
+            node[:service_openflow].dispatch_publish(event, options)
+          }
         end
 
-        node[:service_openflow].publish(event, options)
-      }
+      rescue Celluloid::DeadActorError => e
+        info "publish_event->#{node_id}: could not send #{event}, service_openflow actor is dead"
+      end
     end
 
     private

--- a/vnet/lib/vnet/node_modules/service_openflow.rb
+++ b/vnet/lib/vnet/node_modules/service_openflow.rb
@@ -76,16 +76,6 @@ module Vnet
       include Celluloid::Logger
       include Vnet::Event::Dispatchable
 
-      def self.prepare_controller(trema_thread)
-        Celluloid.logger.info "trema: pid_directory:'#{Trema.pid}'."
-
-        Vnet::Openflow::Controller.new.tap { |controller|
-          controller.init_trema
-          controller.open_trema_tasks
-          controller.trema_thread = trema_thread
-        }
-      end
-
       def set_controller(controller)
         @controller = controller
       end

--- a/vnet/lib/vnet/node_modules/service_openflow.rb
+++ b/vnet/lib/vnet/node_modules/service_openflow.rb
@@ -76,23 +76,24 @@ module Vnet
       include Celluloid::Logger
       include Vnet::Event::Dispatchable
 
-      def initialize
-        @controller = Vnet::Openflow::Controller.new
+      def self.prepare_controller(trema_thread)
+        Celluloid.logger.info "trema: pid_directory:'#{Trema.pid}'."
+
+        Vnet::Openflow::Controller.new.tap { |controller|
+          controller.init_trema
+          controller.open_trema_tasks
+          controller.trema_thread = trema_thread
+        }
       end
 
-      def prepare_controller(trema_thread)
-        info "trema: pid_directory:'#{Trema.pid}'."
-
-        conf = Vnet::Configurations::Vna.conf
-
-        @controller.init_trema
-        @controller.open_trema_tasks
-        @controller.trema_thread = trema_thread
-        @controller
+      def set_controller(controller)
+        @controller = controller
       end
 
       def terminate
         info "service_openflow: terminating"
+
+        return if @controller.nil?
 
         @controller.pass_task {
           begin

--- a/vnet/lib/vnet/node_modules/service_openflow.rb
+++ b/vnet/lib/vnet/node_modules/service_openflow.rb
@@ -71,7 +71,6 @@ module Vnet
     end
 
     class ServiceOpenflow
-
       include Celluloid
       include Celluloid::Notifications
       include Celluloid::Logger
@@ -79,28 +78,17 @@ module Vnet
 
       def initialize
         @controller = Vnet::Openflow::Controller.new
-
-        start
       end
 
-      def start
+      def prepare_controller(trema_thread)
         info "trema: pid_directory:'#{Trema.pid}'."
 
         conf = Vnet::Configurations::Vna.conf
 
         @controller.init_trema
         @controller.open_trema_tasks
-
-        # Make sure we use the default Thread instead of any Celluloid
-        # extensions.
-        @controller.trema_thread = ::Thread.new {
-          begin
-            @controller.run_no_init!
-          rescue Exception => e
-            p e.inspect
-            e.backtrace.each { |str| p str }
-          end
-        }
+        @controller.trema_thread = trema_thread
+        @controller
       end
 
       def terminate

--- a/vnet/lib/vnet/services/vnmgr.rb
+++ b/vnet/lib/vnet/services/vnmgr.rb
@@ -24,6 +24,11 @@ module Vnet::Services
       info log_format('initialized managers')
     end
 
+    def dispatch_publish(event, options)
+      publish(event, options)
+      nil
+    end
+
     #
     # Internal methods:
     #

--- a/vnet/spec/vnet/node_modules/event_handler_spec.rb
+++ b/vnet/spec/vnet/node_modules/event_handler_spec.rb
@@ -12,13 +12,17 @@ describe Vnet::NodeModules::EventHandler do
     it "handle correctly" do
       options = {:bbb => 1, :ccc => 2}
       node = double(:node)
+      node2 = double(:node)
       actor = double(:actor)
 
-      allow(DCell::Node).to receive(:[]).with("vna").and_return(node)
+      allow(DCell).to receive(:me).and_return(node2)
+      allow(node2).to receive(:id).and_return('vna2')
+
+      allow(DCell::Node).to receive(:[]).with('vna').and_return(node)
 
       expect(node).to receive(:[]).with(:service_openflow).exactly(2).times.and_return(actor)
       expect(node).to receive(:state).and_return(:connected)
-      expect(actor).to receive(:publish).with(:aaa, options)
+      expect(actor).to receive(:dispatch_publish).with(:aaa, options)
 
       Vnet::NodeModules::EventHandler.new.handle_event(:aaa, options)
     end


### PR DESCRIPTION
Don't spawn an additional thread for trema, and initialize trema before dcell is loaded to ensure fork doesn't cause issues.

Other small improvements to how events are dispatched by the event handler.