### PR TITLE
Test unlink managers

### DIFF
--- a/integration_test/lib/vnspec/spec/router_p2v_spec.rb
+++ b/integration_test/lib/vnspec/spec/router_p2v_spec.rb
@@ -3,6 +3,11 @@
 require_relative 'spec_helper'
 
 describe 'router_p2v' do
+  before(:all) do
+    # Give extra time for the vm's and vna's to start up.
+    sleep 30
+  end
+
   describe 'public to public' do
     context 'vm1 to vm3' do
       it 'reachable' do

--- a/vnet/bin/vna
+++ b/vnet/bin/vna
@@ -9,12 +9,14 @@ require 'vnet'
 
 # Start the switch manager before any celluloid services in order to
 # avoid cloned file descriptors to e.g. zmq remaining open.
-Vnet::NodeModules::SwitchManager.new.tap { |sm|
+Vnet::Openflow::SwitchManager.new.tap { |sm|
   sm.configure_trema
   sm.cleanup_current_session
   sm.kill_old_switches
   sm.start
 }
+
+require 'celluloid'
 
 controller = Vnet::Openflow::Controller.new.tap { |controller|
   controller.init_trema
@@ -22,7 +24,6 @@ controller = Vnet::Openflow::Controller.new.tap { |controller|
   controller.trema_thread = Thread.current
 }
 
-require 'celluloid'
 require 'celluloid/autostart'
 require 'dcell'
 

--- a/vnet/bin/vna
+++ b/vnet/bin/vna
@@ -44,16 +44,16 @@ params = {
 
 params.merge!(:public => conf.node.pub_addr_string) if conf.node.addr.public != ""
 
-DCell.start(params)
-
-
 trap 'TTIN' do
   Celluloid.stack_dump
 end
 
-Vnet::NodeModules::ServiceOpenflow.supervise_as :service_openflow
+Vnet::NodeModules::ServiceOpenflow.prepare_controller(Thread.current).tap { |controller|
+  DCell.start(params)
 
-Celluloid::Actor[:service_openflow].prepare_controller(Thread.current).tap { |controller|
+  Vnet::NodeModules::ServiceOpenflow.supervise_as :service_openflow
+  Celluloid::Actor[:service_openflow].set_controller(controller)
+
   Celluloid.logger.debug "starting trema controller on thread #{Thread.current.inspect}"
   controller.run_no_init!
 }

--- a/vnet/bin/vna
+++ b/vnet/bin/vna
@@ -9,11 +9,18 @@ require 'vnet'
 
 # Start the switch manager before any celluloid services in order to
 # avoid cloned file descriptors to e.g. zmq remaining open.
-switch_manager_new = Vnet::NodeModules::SwitchManager.new
-switch_manager_new.configure_trema
-switch_manager_new.cleanup_current_session
-switch_manager_new.kill_old_switches
-switch_manager_new.start
+Vnet::NodeModules::SwitchManager.new.tap { |sm|
+  sm.configure_trema
+  sm.cleanup_current_session
+  sm.kill_old_switches
+  sm.start
+}
+
+controller = Vnet::Openflow::Controller.new.tap { |controller|
+  controller.init_trema
+  controller.open_trema_tasks
+  controller.trema_thread = Thread.current
+}
 
 require 'celluloid'
 require 'celluloid/autostart'
@@ -49,12 +56,10 @@ trap 'TTIN' do
   Celluloid.stack_dump
 end
 
-Vnet::NodeModules::ServiceOpenflow.prepare_controller(Thread.current).tap { |controller|
-  DCell.start(params)
+DCell.start(params)
 
-  Vnet::NodeModules::ServiceOpenflow.supervise_as :service_openflow
-  Celluloid::Actor[:service_openflow].set_controller(controller)
+Vnet::NodeModules::ServiceOpenflow.supervise_as :service_openflow
+Celluloid::Actor[:service_openflow].set_controller(controller)
 
-  Celluloid.logger.debug "starting trema controller on thread #{Thread.current.inspect}"
-  controller.run_no_init!
-}
+Celluloid.logger.debug "starting trema controller on thread #{Thread.current.inspect}"
+controller.run_no_init!

--- a/vnet/bin/vna
+++ b/vnet/bin/vna
@@ -6,13 +6,6 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'rubygems'
 require 'bundler/setup'
 require 'vnet'
-require 'celluloid'
-require 'celluloid/autostart'
-require 'dcell'
-
-#Vnet::Initializers::Logger.run("vna.log")
-
-conf = Vnet::Configurations::Vna.conf
 
 # Start the switch manager before any celluloid services in order to
 # avoid cloned file descriptors to e.g. zmq remaining open.
@@ -21,6 +14,14 @@ switch_manager_new.configure_trema
 switch_manager_new.cleanup_current_session
 switch_manager_new.kill_old_switches
 switch_manager_new.start
+
+require 'celluloid'
+require 'celluloid/autostart'
+require 'dcell'
+
+#Vnet::Initializers::Logger.run("vna.log")
+
+conf = Vnet::Configurations::Vna.conf
 
 Vnet::NodeApi.set_proxy(conf.node_api_proxy)
 Vnet::NodeApi.raise_on_error = false # dont raise any errors

--- a/vnet/bin/vna
+++ b/vnet/bin/vna
@@ -53,4 +53,7 @@ end
 
 Vnet::NodeModules::ServiceOpenflow.supervise_as :service_openflow
 
-sleep
+Celluloid::Actor[:service_openflow].prepare_controller(Thread.current).tap { |controller|
+  Celluloid.logger.debug "starting trema controller on thread #{Thread.current.inspect}"
+  controller.run_no_init!
+}

--- a/vnet/lib/vnet.rb
+++ b/vnet/lib/vnet.rb
@@ -536,7 +536,6 @@ module Vnet
     autoload :Rpc, 'vnet/node_modules/rpc'
     autoload :EventHandler, 'vnet/node_modules/event_handler'
     autoload :ServiceOpenflow, 'vnet/node_modules/service_openflow'
-    autoload :SwitchManager, 'vnet/node_modules/service_openflow'
   end
 
   module Openflow
@@ -550,6 +549,7 @@ module Vnet
     autoload :OvsOfctl, 'vnet/openflow/ovs_ofctl'
     autoload :PacketHelpers, 'vnet/openflow/packet_handler'
     autoload :Switch, 'vnet/openflow/switch'
+    autoload :SwitchManager, 'vnet/openflow/switch_manager'
     autoload :TremaTasks, 'vnet/openflow/trema_tasks'
   end
 

--- a/vnet/lib/vnet/core/active_manager.rb
+++ b/vnet/lib/vnet/core/active_manager.rb
@@ -3,8 +3,6 @@
 module Vnet::Core
   class ActiveManager < Vnet::Core::Manager
 
-    event_handler_default_drop_all
-
     finalizer :do_cleanup
 
     #

--- a/vnet/lib/vnet/core/datapath_manager.rb
+++ b/vnet/lib/vnet/core/datapath_manager.rb
@@ -8,7 +8,6 @@ module Vnet::Core
     #
     # Events:
     #
-    event_handler_default_drop_all
 
     subscribe_event DATAPATH_INITIALIZED, :load_item
     subscribe_event DATAPATH_UNLOAD_ITEM, :unload_item

--- a/vnet/lib/vnet/core/filter_manager.rb
+++ b/vnet/lib/vnet/core/filter_manager.rb
@@ -10,7 +10,6 @@ module Vnet::Core
     #
     # Events:
     #
-    event_handler_default_drop_all
 
     subscribe_event FILTER_INITIALIZED, :load_item
     subscribe_event FILTER_UNLOAD_ITEM, :unload_item

--- a/vnet/lib/vnet/core/interface_manager.rb
+++ b/vnet/lib/vnet/core/interface_manager.rb
@@ -9,7 +9,6 @@ module Vnet::Core
     #
     # Events:
     #
-    event_handler_default_drop_all
 
     subscribe_event INTERFACE_INITIALIZED, :load_item
     subscribe_event INTERFACE_UNLOAD_ITEM, :unload_item

--- a/vnet/lib/vnet/core/interface_network_manager.rb
+++ b/vnet/lib/vnet/core/interface_network_manager.rb
@@ -7,7 +7,6 @@ module Vnet::Core
     #
     # Events:
     #
-    event_handler_default_drop_all
 
     subscribe_event INTERFACE_NETWORK_INITIALIZED, :load_item
     subscribe_event INTERFACE_NETWORK_UNLOAD_ITEM, :unload_item

--- a/vnet/lib/vnet/core/interface_port_manager.rb
+++ b/vnet/lib/vnet/core/interface_port_manager.rb
@@ -9,7 +9,6 @@ module Vnet::Core
     #
     # Events:
     #
-    event_handler_default_drop_all
 
     subscribe_event INTERFACE_PORT_INITIALIZED, :load_item
     subscribe_event INTERFACE_PORT_UNLOAD_ITEM, :unload_item

--- a/vnet/lib/vnet/core/interface_route_link_manager.rb
+++ b/vnet/lib/vnet/core/interface_route_link_manager.rb
@@ -7,7 +7,6 @@ module Vnet::Core
     #
     # Events:
     #
-    event_handler_default_drop_all
 
     subscribe_event INTERFACE_ROUTE_LINK_INITIALIZED, :load_item
     subscribe_event INTERFACE_ROUTE_LINK_UNLOAD_ITEM, :unload_item

--- a/vnet/lib/vnet/core/interface_segment_manager.rb
+++ b/vnet/lib/vnet/core/interface_segment_manager.rb
@@ -7,7 +7,6 @@ module Vnet::Core
     #
     # Events:
     #
-    event_handler_default_drop_all
 
     subscribe_event INTERFACE_SEGMENT_INITIALIZED, :load_item
     subscribe_event INTERFACE_SEGMENT_UNLOAD_ITEM, :unload_item

--- a/vnet/lib/vnet/core/manager.rb
+++ b/vnet/lib/vnet/core/manager.rb
@@ -26,6 +26,23 @@ module Vnet::Core
       end
     end
 
+    def set_datapath_info(datapath_info)
+      if @datapath_info
+        raise("Manager.set_datapath_info called twice.")
+      end
+
+      if datapath_info.nil? || datapath_info.id.nil?
+        raise("Manager.set_datapath_info received invalid datapath info: #{datapath_info.inspect}")
+      end
+
+      @datapath_info = datapath_info
+
+      # We need to update remote interfaces in case they are now in
+      # our datapath.
+      initialized_datapath_info
+      nil
+    end
+
     #
     # Internal methods:
     #

--- a/vnet/lib/vnet/core/network_manager.rb
+++ b/vnet/lib/vnet/core/network_manager.rb
@@ -11,7 +11,6 @@ module Vnet::Core
     #
     # Events:
     #
-    event_handler_default_drop_all
 
     # Networks have no created item event as they always get loaded
     # when used by other managers.

--- a/vnet/lib/vnet/core/port_manager.rb
+++ b/vnet/lib/vnet/core/port_manager.rb
@@ -7,7 +7,6 @@ module Vnet::Core
     #
     # Events:
     #
-    event_handler_default_drop_all
 
     subscribe_event PORT_INITIALIZED, :install_item
     subscribe_event PORT_FINALIZED, :uninstall_item

--- a/vnet/lib/vnet/core/route_manager.rb
+++ b/vnet/lib/vnet/core/route_manager.rb
@@ -9,7 +9,6 @@ module Vnet::Core
     #
     # Events:
     #
-    event_handler_default_drop_all
 
     subscribe_event ROUTE_INITIALIZED, :load_item
     subscribe_event ROUTE_UNLOAD_ITEM, :unload_item

--- a/vnet/lib/vnet/core/router_manager.rb
+++ b/vnet/lib/vnet/core/router_manager.rb
@@ -7,7 +7,6 @@ module Vnet::Core
     #
     # Events:
     #
-    event_handler_default_drop_all
 
     subscribe_event ROUTER_INITIALIZED, :load_item
     subscribe_event ROUTER_UNLOAD_ITEM, :unload_item

--- a/vnet/lib/vnet/core/segment_manager.rb
+++ b/vnet/lib/vnet/core/segment_manager.rb
@@ -10,7 +10,6 @@ module Vnet::Core
     #
     # Events:
     #
-    event_handler_default_drop_all
 
     subscribe_event SEGMENT_INITIALIZED, :load_item
     subscribe_event SEGMENT_UNLOAD_ITEM, :unload_item

--- a/vnet/lib/vnet/core/service_manager.rb
+++ b/vnet/lib/vnet/core/service_manager.rb
@@ -9,7 +9,6 @@ module Vnet::Core
     #
     # Events:
     #
-    event_handler_default_drop_all
 
     subscribe_event SERVICE_INITIALIZED, :load_item
     subscribe_event SERVICE_UNLOAD_ITEM, :unload_item

--- a/vnet/lib/vnet/core/translation_manager.rb
+++ b/vnet/lib/vnet/core/translation_manager.rb
@@ -10,7 +10,6 @@ module Vnet::Core
     #
     # Events:
     #
-    event_handler_default_drop_all
 
     subscribe_event TRANSLATION_INITIALIZED, :load_item
     subscribe_event TRANSLATION_UNLOAD_ITEM, :unload_item

--- a/vnet/lib/vnet/core/tunnel_manager.rb
+++ b/vnet/lib/vnet/core/tunnel_manager.rb
@@ -9,7 +9,6 @@ module Vnet::Core
     #
     # Events:
     #
-    event_handler_default_drop_all
 
     subscribe_event REMOVED_TUNNEL, :unload
     subscribe_event INITIALIZED_TUNNEL, :install_item

--- a/vnet/lib/vnet/event/notifications.rb
+++ b/vnet/lib/vnet/event/notifications.rb
@@ -46,7 +46,7 @@ module Vnet::Event
       end
 
       def event_handler_default_state
-        @event_handler_default_state ||= :active
+        @event_handler_default_state ||= :drop_all
       end
 
       def event_handler_default_active

--- a/vnet/lib/vnet/manager.rb
+++ b/vnet/lib/vnet/manager.rb
@@ -132,24 +132,6 @@ module Vnet
       nil
     end
 
-    # TODO: Move to core/manager.
-    def set_datapath_info(datapath_info)
-      if @datapath_info
-        raise("Manager.set_datapath_info called twice.")
-      end
-
-      if datapath_info.nil? || datapath_info.id.nil?
-        raise("Manager.set_datapath_info received invalid datapath info.")
-      end
-
-      @datapath_info = datapath_info
-
-      # We need to update remote interfaces in case they are now in
-      # our datapath.
-      initialized_datapath_info
-      nil
-    end
-
     def start_initialize
       if @state != :uninitialized
         raise("Manager.start_initialized must be called on an uninitialized manager.")

--- a/vnet/lib/vnet/node_modules/event_handler.rb
+++ b/vnet/lib/vnet/node_modules/event_handler.rb
@@ -100,13 +100,15 @@ module Vnet::NodeModules
 
       begin
         if DCell.me.id == node_id
+          # debug log_format_h("publish_event(local)->#{node_id}: #{event}", options)
+
           Celluloid::Actor[:service_openflow].dispatch_publish(event, options)
         else
+          # debug log_format_h("publish_event(remote)->#{node_id}: #{event}", options)
+
           DCell::Node[node_id].tap { |node|
             # No need to log as a node being disconnected is normal.
             next if node.nil? || node.state != :connected
-
-            # debug log_format_h("publish_event->#{node_id}: #{event}", options)
 
             if node[:service_openflow].nil?
               warn "publish_event->#{node_id}: no service_openflow registered"

--- a/vnet/lib/vnet/node_modules/event_handler.rb
+++ b/vnet/lib/vnet/node_modules/event_handler.rb
@@ -73,8 +73,18 @@ module Vnet::NodeModules
         end
 
       when *VNMGR_EVENTS
-        # debug log_format_h("publish_event->vnmgr: #{event}", options)
-        DCell::Node[:vnmgr][:vnmgr].publish(event, options)
+        begin
+          # debug log_format_h("publish_event->vnmgr: #{event}", options)
+
+          if DCell.me.id == 'vnmgr'
+            Celluloid::Actor[:vnmgr].dispatch_publish(event, options)
+          else
+            DCell::Node['vnmgr'][:vnmgr].dispatch_publish(event, options)
+          end
+
+        rescue Celluloid::DeadActorError => e
+          info "publish_event->vnmgr: could not send #{event}, vnmgr actor is dead"
+        end
 
       else
         # TODO: Refactor. We should not need to query for every single
@@ -86,19 +96,30 @@ module Vnet::NodeModules
     end
 
     def publish_event(node_id, event, options)
-      DCell::Node[node_id].tap { |node|
-        # No need to log as a node being disconnected is normal.
-        next if node.nil? || node.state != :connected
+      raise "tried to use non-string node_id '#{node_id.inspect}'" if !node_id.is_a? String
 
-        # debug log_format_h("publish_event->#{node_id}: #{event}", options)
+      begin
+        if DCell.me.id == node_id
+          Celluloid::Actor[:service_openflow].dispatch_publish(event, options)
+        else
+          DCell::Node[node_id].tap { |node|
+            # No need to log as a node being disconnected is normal.
+            next if node.nil? || node.state != :connected
 
-        if node[:service_openflow].nil?
-          warn "publish_event->#{node_id}: no service_openflow registered"
-          next
+            # debug log_format_h("publish_event->#{node_id}: #{event}", options)
+
+            if node[:service_openflow].nil?
+              warn "publish_event->#{node_id}: no service_openflow registered"
+              next
+            end
+
+            node[:service_openflow].dispatch_publish(event, options)
+          }
         end
 
-        node[:service_openflow].publish(event, options)
-      }
+      rescue Celluloid::DeadActorError => e
+        info "publish_event->#{node_id}: could not send #{event}, service_openflow actor is dead"
+      end
     end
 
     private

--- a/vnet/lib/vnet/node_modules/service_openflow.rb
+++ b/vnet/lib/vnet/node_modules/service_openflow.rb
@@ -76,16 +76,6 @@ module Vnet
       include Celluloid::Logger
       include Vnet::Event::Dispatchable
 
-      def self.prepare_controller(trema_thread)
-        Celluloid.logger.info "trema: pid_directory:'#{Trema.pid}'."
-
-        Vnet::Openflow::Controller.new.tap { |controller|
-          controller.init_trema
-          controller.open_trema_tasks
-          controller.trema_thread = trema_thread
-        }
-      end
-
       def set_controller(controller)
         @controller = controller
       end

--- a/vnet/lib/vnet/node_modules/service_openflow.rb
+++ b/vnet/lib/vnet/node_modules/service_openflow.rb
@@ -76,23 +76,24 @@ module Vnet
       include Celluloid::Logger
       include Vnet::Event::Dispatchable
 
-      def initialize
-        @controller = Vnet::Openflow::Controller.new
+      def self.prepare_controller(trema_thread)
+        Celluloid.logger.info "trema: pid_directory:'#{Trema.pid}'."
+
+        Vnet::Openflow::Controller.new.tap { |controller|
+          controller.init_trema
+          controller.open_trema_tasks
+          controller.trema_thread = trema_thread
+        }
       end
 
-      def prepare_controller(trema_thread)
-        info "trema: pid_directory:'#{Trema.pid}'."
-
-        conf = Vnet::Configurations::Vna.conf
-
-        @controller.init_trema
-        @controller.open_trema_tasks
-        @controller.trema_thread = trema_thread
-        @controller
+      def set_controller(controller)
+        @controller = controller
       end
 
       def terminate
         info "service_openflow: terminating"
+
+        return if @controller.nil?
 
         @controller.pass_task {
           begin

--- a/vnet/lib/vnet/node_modules/service_openflow.rb
+++ b/vnet/lib/vnet/node_modules/service_openflow.rb
@@ -71,7 +71,6 @@ module Vnet
     end
 
     class ServiceOpenflow
-
       include Celluloid
       include Celluloid::Notifications
       include Celluloid::Logger
@@ -79,28 +78,17 @@ module Vnet
 
       def initialize
         @controller = Vnet::Openflow::Controller.new
-
-        start
       end
 
-      def start
+      def prepare_controller(trema_thread)
         info "trema: pid_directory:'#{Trema.pid}'."
 
         conf = Vnet::Configurations::Vna.conf
 
         @controller.init_trema
         @controller.open_trema_tasks
-
-        # Make sure we use the default Thread instead of any Celluloid
-        # extensions.
-        @controller.trema_thread = ::Thread.new {
-          begin
-            @controller.run_no_init!
-          rescue Exception => e
-            p e.inspect
-            e.backtrace.each { |str| p str }
-          end
-        }
+        @controller.trema_thread = trema_thread
+        @controller
       end
 
       def terminate

--- a/vnet/lib/vnet/node_modules/service_openflow.rb
+++ b/vnet/lib/vnet/node_modules/service_openflow.rb
@@ -5,7 +5,6 @@ module Vnet
 
     class ServiceOpenflow
       include Celluloid
-      include Celluloid::Notifications
       include Celluloid::Logger
       include Vnet::Event::Dispatchable
 
@@ -33,7 +32,7 @@ module Vnet
       end
 
       def dispatch_publish(event, options)
-        publish(event, options)
+        Celluloid::Notifications.notifier.publish(event, options)
         nil
       end
 

--- a/vnet/lib/vnet/node_modules/service_openflow.rb
+++ b/vnet/lib/vnet/node_modules/service_openflow.rb
@@ -1,74 +1,7 @@
 # -*- coding: utf-8 -*-
 
-require 'celluloid'
-require 'nio'
-require 'trema'
-require "trema/dsl/context"
-require "trema/util"
-
 module Vnet
   module NodeModules
-
-    class SwitchManager
-      include Trema::Util
-
-      def configure_trema
-        # Trema hack...
-        $verbose = true
-
-        conf = Vnet::Configurations::Vna.conf
-        ENV['TREMA_HOME'] ||= conf.trema_home
-        ENV['TREMA_TMP'] ||= conf.trema_tmp
-        %w(log pid sock).each do |name|
-          FileUtils.mkdir_p(File.join(ENV['TREMA_TMP'], name))
-        end
-      end
-
-      def start
-        bridge_sockets = self.list_bridge_sockets
-        bridge_sockets.each { |path| FileUtils.remove_file(path, true) }
-
-        raise "No OVS bridges defined." if bridge_sockets.empty?
-
-        rule = {
-          :port_status => "Controller",
-          :packet_in => "Controller",
-          :state_notify => "Controller",
-          :vendor => "Controller"
-        }
-
-        # @switch_manager = Trema::SwitchManager.new( rule, nil, bridge_sockets.last )
-        @switch_manager = Trema::SwitchManager.new( rule, 6633, nil )
-        # @switch_manager.command_prefix = "valgrind -q --tool=memcheck --leak-check=yes --trace-children=yes --log-socket=127.0.0.1:12345 "
-
-        system(@switch_manager.command + " --no-cookie-translation")
-      end
-
-      def do_cleanup
-        cleanup_current_session
-      end
-
-      def kill_old_switches
-        Dir.glob(File.join(Trema.pid, "*.pid")).each do | each |
-          # logger.info "trema kill: pid_file:'#{each}'."
-          # info "trema kill: pid_file:'#{each}'."
-          pid = ::IO.read( each ).chomp.to_i
-          system("kill #{pid}") if pid != 0
-        end
-      end
-
-      def list_bridge_sockets
-        # Dcmgr.conf.dc_networks.values.keep_if { |dcn|
-        #   dcn.bridge_type == 'ovs' and !dcn.name.empty?
-        # }.map { |dcn|
-        #   dcn.bridge
-        # }.uniq.map { |bridge|
-        #   "#{Dcmgr.conf.ovs_run_dir}/#{bridge}.controller"
-        # }
-        ['/var/run/openvswitch/br0.controller']
-      end
-
-    end
 
     class ServiceOpenflow
       include Celluloid

--- a/vnet/lib/vnet/openflow/datapath.rb
+++ b/vnet/lib/vnet/openflow/datapath.rb
@@ -73,13 +73,15 @@ module Vnet::Openflow
     end
 
     def run_normal
-      info log_format('starting normal vnet datapath')
+      info log_format('starting normal datapath initialization')
 
       @dp_info.initialize_bootstrap_managers
       wait_for_load_of_host_datapath
-      @dp_info.initialize_main_managers(@datapath_info)
-      wait_for_unload_of_host_datapath
 
+      @dp_info.initialize_main_managers(@datapath_info)
+      info log_format('completed normal datapath initialization')
+
+      wait_for_unload_of_host_datapath
       info log_format('resetting datapath info')
 
       # TODO: Replace with proper terminate.

--- a/vnet/lib/vnet/openflow/datapath.rb
+++ b/vnet/lib/vnet/openflow/datapath.rb
@@ -159,12 +159,6 @@ module Vnet::Openflow
     end
 
     def link_with_managers(managers)
-      vnmgr_node = DCell::Node[:vnmgr]
-
-      if vnmgr_node.nil?
-        warn log_format('could not find vnmgr dcell node, cannot create link for actor cleanup')
-      end
-
       # The DCell messenger should not close before we have had a
       # chance to clean up all managers, however it seems to not work
       # properly.
@@ -174,7 +168,7 @@ module Vnet::Openflow
       managers.each { |manager|
         begin
           link(manager)
-          vnmgr_node && vnmgr_node.link(manager)
+          # vnmgr_node && vnmgr_node.link(manager)
         rescue => e
           error log_format("Fail to link with #{manager.class.name}", e)
           raise e

--- a/vnet/lib/vnet/openflow/datapath.rb
+++ b/vnet/lib/vnet/openflow/datapath.rb
@@ -6,13 +6,19 @@ module Vnet::Openflow
   # static information about this datapath.
   class DatapathInfo
 
+    attr_reader :dpid
+    attr_reader :dpid_2
+
     attr_reader :id
     attr_reader :uuid
     attr_reader :display_name
     attr_reader :node_id
     attr_reader :enable_ovs_learn_action
 
-    def initialize(datapath_map)
+    def initialize(dpid, dpid_s, datapath_map)
+      @dpid = dpid
+      @dpid_s = dpid_s
+
       @id = datapath_map[:id]
       @uuid = datapath_map[:uuid]
       @display_name = datapath_map[:display_name]
@@ -55,7 +61,7 @@ module Vnet::Openflow
 
     def create_switch
       link_with_managers(@dp_info.bootstrap_managers)
-      link_with_managers(@dp_info.managers)
+      link_with_managers(@dp_info.main_managers)
 
       @switch = Switch.new(self)
       link(@switch)
@@ -69,21 +75,16 @@ module Vnet::Openflow
     def run_normal
       info log_format('starting normal vnet datapath')
 
+      @dp_info.initialize_bootstrap_managers
       wait_for_load_of_host_datapath
-
-      info log_format_h('found datapath info',
-                        display_name: @datapath_info.display_name,
-                        node_id: @datapath_info.node_id,
-                        enable_ovs_learn_action: @datapath_info.enable_ovs_learn_action)
-
-      initialize_managers
+      @dp_info.initialize_main_managers(@datapath_info)
       wait_for_unload_of_host_datapath
 
       info log_format('resetting datapath info')
 
-      @dp_info.managers.each { |manager|
-        manager.event_handler_drop_all
-      }
+      # TODO: Replace with proper terminate.
+      @dp_info.bootstrap_managers.each { |manager| manager.event_handler_drop_all }
+      @dp_info.main_managers.each { |manager| manager.event_handler_drop_all }
 
       @controller.pass_task { @controller.reset_datapath(@dpid) }
 
@@ -120,20 +121,9 @@ module Vnet::Openflow
         counter += 1
       end
 
-      @datapath_info = DatapathInfo.new(host_datapath)
+      info log_format_h("found datapath info for #{@dpid_s}", host_datapath.to_h)
 
-      # Make sure datapath manager has the host datapath.
-      #
-      # TODO: This should be done automatically by datapath manager
-      # when it is initialized.
-      #
-      # Since we load the host datapath here, we need to set
-      # queue-only now.
-      @dp_info.managers.each { |manager|
-        manager.event_handler_queue_only
-      }
-
-      @dp_info.datapath_manager.async.retrieve(dpid: @dpid)
+      @datapath_info = DatapathInfo.new(@dpid, @dpid_s, host_datapath)
     end
 
     def wait_for_unload_of_host_datapath
@@ -152,7 +142,8 @@ module Vnet::Openflow
       # We terminate the managers manually rather than relying on
       # actor's 'link' in order to ensure the managers are terminated
       # before Datapath's 'terminate' returns.
-      @dp_info.terminate_managers
+      @dp_info.terminate_main_managers
+      @dp_info.terminate_bootstrap_managers
       @dp_info.del_all_flows
 
       info log_format('cleaned up')
@@ -174,24 +165,6 @@ module Vnet::Openflow
           raise e
         end
       }
-    end
-
-    def initialize_bootstrap_managers
-      managers = @dp_info.bootstrap_managers
-      managers.each { |manager| manager.set_datapath_info(@datapath_info) }
-      managers.each { |manager| manager.event_handler_queue_only }
-      managers.each { |manager| manager.async.start_initialize }
-      managers.each { |manager| manager.wait_for_initialized(nil) }
-      managers.each { |manager| manager.event_handler_active }
-    end
-
-    def initialize_managers
-      managers = @dp_info.managers
-      managers.each { |manager| manager.set_datapath_info(@datapath_info) }
-      managers.each { |manager| manager.event_handler_queue_only }
-      managers.each { |manager| manager.async.start_initialize }
-      managers.each { |manager| manager.wait_for_initialized(nil) }
-      managers.each { |manager| manager.event_handler_active }
     end
 
   end

--- a/vnet/lib/vnet/openflow/switch.rb
+++ b/vnet/lib/vnet/openflow/switch.rb
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-require 'celluloid'
-
 module Vnet::Openflow
 
   class Switch

--- a/vnet/lib/vnet/openflow/switch_manager.rb
+++ b/vnet/lib/vnet/openflow/switch_manager.rb
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+
+require 'nio'
+require 'trema'
+require "trema/dsl/context"
+require "trema/util"
+
+module Vnet::Openflow
+  class SwitchManager
+    include Trema::Util
+
+    def configure_trema
+      # Trema hack...
+      $verbose = true
+
+      conf = Vnet::Configurations::Vna.conf
+      ENV['TREMA_HOME'] ||= conf.trema_home
+      ENV['TREMA_TMP'] ||= conf.trema_tmp
+      %w(log pid sock).each do |name|
+        FileUtils.mkdir_p(File.join(ENV['TREMA_TMP'], name))
+      end
+    end
+
+    def start
+      bridge_sockets = self.list_bridge_sockets
+      bridge_sockets.each { |path| FileUtils.remove_file(path, true) }
+
+      raise "No OVS bridges defined." if bridge_sockets.empty?
+
+      rule = {
+        :port_status => "Controller",
+        :packet_in => "Controller",
+        :state_notify => "Controller",
+        :vendor => "Controller"
+      }
+
+      # @switch_manager = Trema::SwitchManager.new( rule, nil, bridge_sockets.last )
+      @switch_manager = Trema::SwitchManager.new( rule, 6633, nil )
+      # @switch_manager.command_prefix = "valgrind -q --tool=memcheck --leak-check=yes --trace-children=yes --log-socket=127.0.0.1:12345 "
+
+      system(@switch_manager.command + " --no-cookie-translation")
+    end
+
+    def do_cleanup
+      cleanup_current_session
+    end
+
+    def kill_old_switches
+      Dir.glob(File.join(Trema.pid, "*.pid")).each do | each |
+        # logger.info "trema kill: pid_file:'#{each}'."
+        # info "trema kill: pid_file:'#{each}'."
+        pid = ::IO.read( each ).chomp.to_i
+        system("kill #{pid}") if pid != 0
+      end
+    end
+
+    def list_bridge_sockets
+      # Dcmgr.conf.dc_networks.values.keep_if { |dcn|
+      #   dcn.bridge_type == 'ovs' and !dcn.name.empty?
+      # }.map { |dcn|
+      #   dcn.bridge
+      # }.uniq.map { |bridge|
+      #   "#{Dcmgr.conf.ovs_run_dir}/#{bridge}.controller"
+      # }
+      ['/var/run/openvswitch/br0.controller']
+    end
+
+  end
+end

--- a/vnet/lib/vnet/services/ip_retention_container_manager.rb
+++ b/vnet/lib/vnet/services/ip_retention_container_manager.rb
@@ -11,7 +11,6 @@ module Vnet::Services
     #
     # Events:
     #
-    event_handler_default_drop_all
 
     subscribe_event IP_RETENTION_CONTAINER_INITIALIZED, :load_item
     subscribe_event IP_RETENTION_CONTAINER_UNLOAD_ITEM, :unload_item

--- a/vnet/lib/vnet/services/lease_policy_manager.rb
+++ b/vnet/lib/vnet/services/lease_policy_manager.rb
@@ -9,7 +9,6 @@ module Vnet::Services
     #
     # Events:
     #
-    event_handler_default_drop_all
 
     subscribe_event LEASE_POLICY_INITIALIZED, :install_item
     subscribe_event LEASE_POLICY_CREATED_ITEM, :create_item

--- a/vnet/lib/vnet/services/topology_manager.rb
+++ b/vnet/lib/vnet/services/topology_manager.rb
@@ -8,7 +8,6 @@ module Vnet::Services
     #
     # Events:
     #
-    event_handler_default_drop_all
 
     subscribe_event TOPOLOGY_INITIALIZED, :load_item
     subscribe_event TOPOLOGY_UNLOAD_ITEM, :unload_item

--- a/vnet/lib/vnet/services/vnmgr.rb
+++ b/vnet/lib/vnet/services/vnmgr.rb
@@ -15,11 +15,7 @@ module Vnet::Services
 
     def do_initialize
       info log_format('initializing managers')
-
-      # Do linking here?...
-
       @vnet_info.start_managers
-
       info log_format('initialized managers')
     end
 

--- a/vnet/lib/vnet/services/vnmgr.rb
+++ b/vnet/lib/vnet/services/vnmgr.rb
@@ -4,7 +4,6 @@ module Vnet::Services
   class Vnmgr
     include Celluloid
     include Celluloid::Logger
-    include Celluloid::Notifications
 
     attr_reader :vnet_info
 
@@ -25,7 +24,7 @@ module Vnet::Services
     end
 
     def dispatch_publish(event, options)
-      publish(event, options)
+      Celluloid::Notifications.notifier.publish(event, options)
       nil
     end
 

--- a/vnet/lib/vnet/services/vnmgr.rb
+++ b/vnet/lib/vnet/services/vnmgr.rb
@@ -24,6 +24,11 @@ module Vnet::Services
       info log_format('initialized managers')
     end
 
+    def dispatch_publish(event, options)
+      publish(event, options)
+      nil
+    end
+
     #
     # Internal methods:
     #

--- a/vnet/spec/support/mock_datapath.rb
+++ b/vnet/spec/support/mock_datapath.rb
@@ -34,13 +34,13 @@ class MockDatapath < Vnet::Openflow::Datapath
   end
 
   def create_datapath_map
-    @datapath_info = Vnet::Openflow::DatapathInfo.new(MW::Datapath[:dpid => @dp_info.dpid_s])
-    initialize_managers
+    @datapath_info = Vnet::Openflow::DatapathInfo.new(@dpid, @dpid_s, MW::Datapath[:dpid => @dp_info.dpid_s])
+    @dp_info.initialize_main_managers
   end
 
   def create_mock_datapath_map
-    @datapath_info = Vnet::Openflow::DatapathInfo.new(OpenStruct.new(dpid: @dp_info.dpid_s, id: 1, uuid: 'dp-test1'))
-    initialize_managers
+    @datapath_info = Vnet::Openflow::DatapathInfo.new(@dpid, @dpid_s, OpenStruct.new(dpid: @dp_info.dpid_s, id: 1, uuid: 'dp-test1'))
+    @dp_info.initialize_main_managers(@datapath_info)
   end
 
   def create_mock_switch

--- a/vnet/spec/vnet/event/notifications_spec.rb
+++ b/vnet/spec/vnet/event/notifications_spec.rb
@@ -13,9 +13,11 @@ describe Vnet::Event::Notifications do
         attr_accessor :db_items
         attr_reader :items, :executed_methods
 
-        subscribe_event "item_created", :create_item
-        subscribe_event "item_updated", :update_item
-        subscribe_event "item_deleted", :delete_item
+        event_handler_default_active
+
+        subscribe_event 'item_created', :create_item
+        subscribe_event 'item_updated', :update_item
+        subscribe_event 'item_deleted', :delete_item
 
         def initialize(options = {})
           @items = {}

--- a/vnet/spec/vnet/node_modules/event_handler_spec.rb
+++ b/vnet/spec/vnet/node_modules/event_handler_spec.rb
@@ -12,13 +12,17 @@ describe Vnet::NodeModules::EventHandler do
     it "handle correctly" do
       options = {:bbb => 1, :ccc => 2}
       node = double(:node)
+      node2 = double(:node)
       actor = double(:actor)
 
-      allow(DCell::Node).to receive(:[]).with("vna").and_return(node)
+      allow(DCell).to receive(:me).and_return(node2)
+      allow(node2).to receive(:id).and_return('vna2')
+
+      allow(DCell::Node).to receive(:[]).with('vna').and_return(node)
 
       expect(node).to receive(:[]).with(:service_openflow).exactly(2).times.and_return(actor)
       expect(node).to receive(:state).and_return(:connected)
-      expect(actor).to receive(:publish).with(:aaa, options)
+      expect(actor).to receive(:dispatch_publish).with(:aaa, options)
 
       Vnet::NodeModules::EventHandler.new.handle_event(:aaa, options)
     end


### PR DESCRIPTION
Don't spawn an additional thread for trema, and initialize trema before dcell is loaded to ensure fork doesn't cause issues.

Other small improvements to how events are dispatched by the event handler.

No longer link the dcell messenger node to managers.