### PR TITLE
Disabled 'tap' method for all celluloid proxies and removed all uses.

### DIFF
--- a/vnet/bin/console
+++ b/vnet/bin/console
@@ -5,9 +5,10 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 require 'rubygems'
 require 'bundler/setup'
-require 'dcell'
 require 'vnet/api_rpc'
 #require 'vnet/api_direct'
+require 'dcell'
+require 'ext/celluloid'
 require 'pry'
 
 # TODO: Add direct api proxy option, which makes sure vnmgr is not running.

--- a/vnet/bin/vna
+++ b/vnet/bin/vna
@@ -6,9 +6,8 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'rubygems'
 require 'bundler/setup'
 require 'vnet/api_rpc'
-require 'celluloid'
-require 'celluloid/autostart'
 require 'dcell'
+require 'ext/celluloid'
 
 #Vnet::Initializers::Logger.run("vna.log")
 
@@ -37,6 +36,7 @@ params = {
 params.merge!(:public => conf.node.pub_addr_string) if conf.node.addr.public != ""
 
 DCell.start(params)
+Celluloid.start
 
 trap 'TTIN' do
   Celluloid.stack_dump

--- a/vnet/bin/vnmgr
+++ b/vnet/bin/vnmgr
@@ -5,13 +5,15 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 require 'rubygems'
 require 'bundler/setup'
-require 'dcell'
 require 'vnet/api_direct'
+require 'dcell'
+require 'ext/celluloid'
 
 # Vnet::Initializers::Logger.run("vnmgr.log")
 
 conf = Vnet::Configurations::Vnmgr.conf
 
+# TODO: Move to after celluloid/dcell is started?
 Vnet::Initializers::DB.run(conf.db_uri)
 
 params = {
@@ -27,7 +29,6 @@ params = {
 params.merge!(:public => conf.node.pub_addr_string) if conf.node.addr.public != ""
 
 DCell.start(params)
-
 Celluloid.start
 
 Vnet::NodeModules::Rpc.supervise_as :rpc

--- a/vnet/lib/ext/celluloid.rb
+++ b/vnet/lib/ext/celluloid.rb
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+require 'celluloid/proxies/abstract_proxy'
+
+module Celluloid
+  class AbstractProxy
+    def tap
+      raise "OpenVNet has disabled tap method for all Celluloid proxies."
+    end
+  end
+end

--- a/vnet/lib/vnet.rb
+++ b/vnet/lib/vnet.rb
@@ -14,6 +14,10 @@ require 'json'
 require 'logger'
 require 'ostruct'
 
+if defined?(::Celluloid)
+  raise "Celluloid module loaded before Vnet."
+end
+
 module Vnet
 
   ROOT = ENV['VNET_ROOT'] || File.expand_path('../../', __FILE__)

--- a/vnet/lib/vnet/node_modules/event_handler.rb
+++ b/vnet/lib/vnet/node_modules/event_handler.rb
@@ -72,8 +72,18 @@ module Vnet::NodeModules
         end
 
       when *VNMGR_EVENTS
-        # debug log_format_h("publish_event->vnmgr: #{event}", options)
-        DCell::Node[:vnmgr][:vnmgr].publish(event, options)
+        begin
+          # debug log_format_h("publish_event->vnmgr: #{event}", options)
+
+          if DCell.me.id == 'vnmgr'
+            Celluloid::Actor[:vnmgr].dispatch_publish(event, options)
+          else
+            DCell::Node['vnmgr'][:vnmgr].dispatch_publish(event, options)
+          end
+
+        rescue Celluloid::DeadActorError => e
+          info "publish_event->vnmgr: could not send #{event}, vnmgr actor is dead"
+        end
 
       else
         # TODO: Refactor. We should not need to query for every single
@@ -85,19 +95,32 @@ module Vnet::NodeModules
     end
 
     def publish_event(node_id, event, options)
-      DCell::Node[node_id].tap { |node|
-        # No need to log as a node being disconnected is normal.
-        next if node.nil? || node.state != :connected
+      raise "tried to use non-string node_id '#{node_id.inspect}'" if !node_id.is_a? String
 
-        # debug log_format_h("publish_event->#{node_id}: #{event}", options)
+      begin
+        if DCell.me.id == node_id
+          # debug log_format_h("publish_event(local)->#{node_id}: #{event}", options)
 
-        if node[:service_openflow].nil?
-          warn "publish_event->#{node_id}: no service_openflow registered"
-          next
+          Celluloid::Actor[:service_openflow].dispatch_publish(event, options)
+        else
+          # debug log_format_h("publish_event(remote)->#{node_id}: #{event}", options)
+
+          node = DCell::Node[node_id]
+          return if node.nil? || node.state != :connected
+
+          service = node[:service_openflow]
+
+          if service.nil?
+            warn "publish_event->#{node_id}: no service_openflow registered"
+            return
+          end
+
+          service.dispatch_publish(event, options)
         end
 
-        node[:service_openflow].publish(event, options)
-      }
+      rescue Celluloid::DeadActorError => e
+        info "publish_event->#{node_id}: could not send #{event}, service_openflow actor is dead"
+      end
     end
 
     private

--- a/vnet/lib/vnet/node_modules/service_openflow.rb
+++ b/vnet/lib/vnet/node_modules/service_openflow.rb
@@ -73,7 +73,6 @@ module Vnet
     class ServiceOpenflow
 
       include Celluloid
-      include Celluloid::Notifications
       include Celluloid::Logger
       include Vnet::Event::Dispatchable
 
@@ -121,7 +120,7 @@ module Vnet
       end
 
       def dispatch_publish(event, options)
-        publish(event, options)
+        Celluloid::Notifications.notifier.publish(event, options)
         nil
       end
 

--- a/vnet/lib/vnet/services/vnmgr.rb
+++ b/vnet/lib/vnet/services/vnmgr.rb
@@ -4,7 +4,6 @@ module Vnet::Services
   class Vnmgr
     include Celluloid
     include Celluloid::Logger
-    include Celluloid::Notifications
 
     attr_reader :vnet_info
 
@@ -42,6 +41,11 @@ module Vnet::Services
       info log_format("cleanup of service managers")
 
       @vnet_info.service_managers.each { |manager| manager.event_handler_drop_all }
+    end
+
+    def dispatch_publish(event, options)
+      Celluloid::Notifications.notifier.publish(event, options)
+      nil
     end
 
     #

--- a/vnet/spec/spec_helper.rb
+++ b/vnet/spec/spec_helper.rb
@@ -7,9 +7,10 @@ Bundler.setup(:default)
 #Bundler.require(:default, :test)
 Bundler.require(:test)
 
-require 'dcell'
-require 'trema' # Needed for the to_trema_hash methods in mock_datapath
 require 'vnet/api_direct'
+require 'dcell'
+require 'ext/celluloid'
+require 'trema' # Needed for the to_trema_hash methods in mock_datapath
 
 Dir['./spec/helpers/*.rb'].map {|f| require f }
 Dir['./spec/support/*.rb'].map {|f| require f }

--- a/vnet/spec/support/mock_datapath.rb
+++ b/vnet/spec/support/mock_datapath.rb
@@ -66,7 +66,7 @@ class MockDatapath < Vnet::Openflow::Datapath
 end
 
 def create_mock_datapath
-  MockDatapath.new(double, 1).tap do |datapath|
-    datapath.create_mock_datapath_map
-  end
+  dp = MockDatapath.new(double, 1)
+  dp.create_mock_datapath_map
+  dp
 end

--- a/vnet/spec/support/mock_event_handler.rb
+++ b/vnet/spec/support/mock_event_handler.rb
@@ -19,17 +19,17 @@ class MockEventHandler
   end
 
   def handle_event(event, params = {})
-    self.class.pass_events[event].tap { |target|
-      if target
-        #puts "pass event event:#{event} params:#{params}"
-        target.publish(event, params)
-      else
-        {event: event, :options => params}.tap { |ev|
-          self.handled_events << ev
-          self.class.handled_events << ev
-        }
-      end
-    }
+    target = self.class.pass_events[event]
+
+    if target
+      #puts "pass event event:#{event} params:#{params}"
+      target.publish(event, params)
+    else
+      {event: event, :options => params}.tap { |ev|
+        self.handled_events << ev
+        self.class.handled_events << ev
+      }
+    end
   end
 
   def async

--- a/vnet/spec/vnet/event/notifications_spec.rb
+++ b/vnet/spec/vnet/event/notifications_spec.rb
@@ -106,9 +106,9 @@ describe Vnet::Event::Notifications do
 
   describe 'with an active manager' do
     let(:manager) do
-      MockEventManager.new.tap { |manager|
-        manager.event_handler_active
-      }
+      m = MockEventManager.new
+      m.event_handler_active
+      m
     end
 
     include_examples 'handle basic events', false
@@ -116,9 +116,9 @@ describe Vnet::Event::Notifications do
 
   describe 'with a queue-only manager' do
     let(:manager) do
-      MockEventManager.new.tap { |manager|
-        manager.event_handler_queue_only
-      }
+      m = MockEventManager.new
+      m.event_handler_queue_only
+      m
     end
 
     include_examples 'handle basic events', true
@@ -154,9 +154,9 @@ describe Vnet::Event::Notifications do
 
   describe 'database changes' do
     let(:manager) do
-      MockEventManager.new.tap { |manager|
-        manager.event_handler_active
-      }
+      m = MockEventManager.new
+      m.event_handler_active
+      m
     end
 
     it 'handle events correctly' do

--- a/vnet/spec/vnet/node_modules/event_handler_spec.rb
+++ b/vnet/spec/vnet/node_modules/event_handler_spec.rb
@@ -12,13 +12,17 @@ describe Vnet::NodeModules::EventHandler do
     it "handle correctly" do
       options = {:bbb => 1, :ccc => 2}
       node = double(:node)
+      node2 = double(:node)
       actor = double(:actor)
 
-      allow(DCell::Node).to receive(:[]).with("vna").and_return(node)
+      allow(DCell).to receive(:me).and_return(node2)
+      allow(node2).to receive(:id).and_return('vna2')
 
-      expect(node).to receive(:[]).with(:service_openflow).exactly(2).times.and_return(actor)
+      allow(DCell::Node).to receive(:[]).with('vna').and_return(node)
+
+      expect(node).to receive(:[]).with(:service_openflow).exactly(1).times.and_return(actor)
       expect(node).to receive(:state).and_return(:connected)
-      expect(actor).to receive(:publish).with(:aaa, options)
+      expect(actor).to receive(:dispatch_publish).with(:aaa, options)
 
       Vnet::NodeModules::EventHandler.new.handle_event(:aaa, options)
     end


### PR DESCRIPTION
Using tap on actors and nodes was sending the block to be executed in the actor's context, fixed so any tap calls on celluloid actors throws an exception.